### PR TITLE
fix: improve edit tool with backup for atomic writes

### DIFF
--- a/ch02/tool/edit.go
+++ b/ch02/tool/edit.go
@@ -3,7 +3,6 @@ package tool
 import (
 	"context"
 	"encoding/json"
-	"io"
 	"os"
 	"strings"
 


### PR DESCRIPTION
修复ch02中的edit工具问题：
- 文件指针问题 ： io.ReadAll(file) 读取后，文件指针已移到文件末尾。 io.WriteString(file, replaced) 会 追加 到末尾，而不是替换原内容。
- 文件未截断 ：没有 O_TRUNC 标志。如果替换后内容比原内容短，文件中会残留旧内容。

新的实现：
使用备份文件实现原子写入
1. 先读取原文件 → 创建 .bak 备份文件
2. 执行替换 → 写入新内容到原文件
3. 失败恢复 → 如果写入出错，从备份恢复原文件
4. 成功清理 → 删除备份文件