### PR TITLE
[codex] fix tui stream finalization race

### DIFF
--- a/ch04/tui/tui.go
+++ b/ch04/tui/tui.go
@@ -88,9 +88,12 @@ type activeStream struct {
 	events <-chan ch04.MessageVO
 	cancel context.CancelFunc
 
-	turnLogLen  int
-	reasonBody  int
-	contentBody int
+	turnLogLen   int
+	reasonBody   int
+	contentBody  int
+	streamClosed bool
+	doneReceived bool
+	doneErr      error
 }
 
 type TuiViewModel struct {
@@ -188,6 +191,10 @@ func (m *TuiViewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case streamClosedMsg:
 		if m.active != nil {
 			m.active.events = nil
+			m.active.streamClosed = true
+			if m.active.doneReceived {
+				return m.finalizeActiveStream()
+			}
 		}
 		return m, nil
 	case streamDoneMsg:
@@ -325,21 +332,13 @@ func (m *TuiViewModel) handleStreamDone(msg streamDoneMsg) (tea.Model, tea.Cmd) 
 		return m, nil
 	}
 
-	m.stopActiveStream()
-	if m.state == stateAborting {
-		m.rollbackTurn()
-		m.notice = "已取消本轮输入。"
-		m.state = stateIdle
+	m.active.doneReceived = true
+	m.active.doneErr = msg.err
+	if !m.active.streamClosed {
 		return m, nil
 	}
 
-	if msg.err != nil {
-		m.logs = append(m.logs, NewError(msg.err.Error()))
-	}
-	m.logs = append(m.logs, NewBorder())
-	m.state = stateIdle
-	m.refreshLogsViewportContent()
-	return m, nil
+	return m.finalizeActiveStream()
 }
 
 func (m *TuiViewModel) startNewTurn(query string) (tea.Model, tea.Cmd) {
@@ -404,6 +403,31 @@ func (m *TuiViewModel) stopActiveStream() {
 		m.active.cancel()
 	}
 	m.active = nil
+}
+
+func (m *TuiViewModel) finalizeActiveStream() (tea.Model, tea.Cmd) {
+	if m.active == nil {
+		m.state = stateIdle
+		return m, nil
+	}
+
+	err := m.active.doneErr
+	if m.state == stateAborting {
+		m.rollbackTurn()
+		m.notice = "已取消本轮输入。"
+		m.stopActiveStream()
+		m.state = stateIdle
+		return m, nil
+	}
+
+	m.stopActiveStream()
+	if err != nil {
+		m.logs = append(m.logs, NewError(err.Error()))
+	}
+	m.logs = append(m.logs, NewBorder())
+	m.state = stateIdle
+	m.refreshLogsViewportContent()
+	return m, nil
 }
 
 func (m *TuiViewModel) scrollUp(n int) {

--- a/ch05/tui/tui.go
+++ b/ch05/tui/tui.go
@@ -34,10 +34,13 @@ type activeStream struct {
 	events <-chan ch05.MessageVO
 	cancel context.CancelFunc
 
-	turnLogLen  int
-	reasonBody  int
-	contentBody int
-	policyBody  int // 当前策略 log entry 的索引
+	turnLogLen   int
+	reasonBody   int
+	contentBody  int
+	policyBody   int // 当前策略 log entry 的索引
+	streamClosed bool
+	doneReceived bool
+	doneErr      error
 }
 
 type TuiViewModel struct {
@@ -132,6 +135,10 @@ func (m *TuiViewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case streamClosedMsg:
 		if m.active != nil {
 			m.active.events = nil
+			m.active.streamClosed = true
+			if m.active.doneReceived {
+				return m.finalizeActiveStream()
+			}
 		}
 		return m, nil
 	case streamDoneMsg:
@@ -286,21 +293,13 @@ func (m *TuiViewModel) handleStreamDone(msg streamDoneMsg) (tea.Model, tea.Cmd) 
 		return m, nil
 	}
 
-	m.stopActiveStream()
-	if m.state == stateAborting {
-		m.rollbackTurn()
-		m.notice = "已取消本轮输入。"
-		m.state = stateIdle
+	m.active.doneReceived = true
+	m.active.doneErr = msg.err
+	if !m.active.streamClosed {
 		return m, nil
 	}
 
-	if msg.err != nil {
-		m.logs = append(m.logs, NewError(msg.err.Error()))
-	}
-	m.logs = append(m.logs, NewBorder())
-	m.state = stateIdle
-	m.refreshLogsViewportContent()
-	return m, nil
+	return m.finalizeActiveStream()
 }
 
 func (m *TuiViewModel) startNewTurn(query string) (tea.Model, tea.Cmd) {
@@ -366,6 +365,31 @@ func (m *TuiViewModel) stopActiveStream() {
 		m.active.cancel()
 	}
 	m.active = nil
+}
+
+func (m *TuiViewModel) finalizeActiveStream() (tea.Model, tea.Cmd) {
+	if m.active == nil {
+		m.state = stateIdle
+		return m, nil
+	}
+
+	err := m.active.doneErr
+	if m.state == stateAborting {
+		m.rollbackTurn()
+		m.notice = "已取消本轮输入。"
+		m.stopActiveStream()
+		m.state = stateIdle
+		return m, nil
+	}
+
+	m.stopActiveStream()
+	if err != nil {
+		m.logs = append(m.logs, NewError(err.Error()))
+	}
+	m.logs = append(m.logs, NewBorder())
+	m.state = stateIdle
+	m.refreshLogsViewportContent()
+	return m, nil
 }
 
 func (m *TuiViewModel) scrollUp(n int) {

--- a/ch06/tui/tui.go
+++ b/ch06/tui/tui.go
@@ -34,11 +34,14 @@ type activeStream struct {
 	events <-chan ch06.MessageVO
 	cancel context.CancelFunc
 
-	turnLogLen  int
-	reasonBody  int
-	contentBody int
-	policyBody  int // 当前策略 log entry 的索引
-	memoryBody  int // 当前记忆更新 log entry 的索引
+	turnLogLen   int
+	reasonBody   int
+	contentBody  int
+	policyBody   int // 当前策略 log entry 的索引
+	memoryBody   int // 当前记忆更新 log entry 的索引
+	streamClosed bool
+	doneReceived bool
+	doneErr      error
 }
 
 type TuiViewModel struct {
@@ -133,6 +136,10 @@ func (m *TuiViewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case streamClosedMsg:
 		if m.active != nil {
 			m.active.events = nil
+			m.active.streamClosed = true
+			if m.active.doneReceived {
+				return m.finalizeActiveStream()
+			}
 		}
 		return m, nil
 	case streamDoneMsg:
@@ -303,21 +310,13 @@ func (m *TuiViewModel) handleStreamDone(msg streamDoneMsg) (tea.Model, tea.Cmd) 
 		return m, nil
 	}
 
-	m.stopActiveStream()
-	if m.state == stateAborting {
-		m.rollbackTurn()
-		m.notice = "已取消本轮输入。"
-		m.state = stateIdle
+	m.active.doneReceived = true
+	m.active.doneErr = msg.err
+	if !m.active.streamClosed {
 		return m, nil
 	}
 
-	if msg.err != nil {
-		m.logs = append(m.logs, NewError(msg.err.Error()))
-	}
-	m.logs = append(m.logs, NewBorder())
-	m.state = stateIdle
-	m.refreshLogsViewportContent()
-	return m, nil
+	return m.finalizeActiveStream()
 }
 
 func (m *TuiViewModel) startNewTurn(query string) (tea.Model, tea.Cmd) {
@@ -384,6 +383,31 @@ func (m *TuiViewModel) stopActiveStream() {
 		m.active.cancel()
 	}
 	m.active = nil
+}
+
+func (m *TuiViewModel) finalizeActiveStream() (tea.Model, tea.Cmd) {
+	if m.active == nil {
+		m.state = stateIdle
+		return m, nil
+	}
+
+	err := m.active.doneErr
+	if m.state == stateAborting {
+		m.rollbackTurn()
+		m.notice = "已取消本轮输入。"
+		m.stopActiveStream()
+		m.state = stateIdle
+		return m, nil
+	}
+
+	m.stopActiveStream()
+	if err != nil {
+		m.logs = append(m.logs, NewError(err.Error()))
+	}
+	m.logs = append(m.logs, NewBorder())
+	m.state = stateIdle
+	m.refreshLogsViewportContent()
+	return m, nil
 }
 
 func (m *TuiViewModel) scrollUp(n int) {

--- a/ch08/tui/tui.go
+++ b/ch08/tui/tui.go
@@ -36,11 +36,14 @@ type activeStream struct {
 	cancel    context.CancelFunc
 	confirmCh chan ch08.ConfirmationAction
 
-	turnLogLen  int
-	reasonBody  int
-	contentBody int
-	policyBody  int // 当前策略 log entry 的索引
-	memoryBody  int // 当前记忆更新 log entry 的索引
+	turnLogLen   int
+	reasonBody   int
+	contentBody  int
+	policyBody   int // 当前策略 log entry 的索引
+	memoryBody   int // 当前记忆更新 log entry 的索引
+	streamClosed bool
+	doneReceived bool
+	doneErr      error
 }
 
 type TuiViewModel struct {
@@ -141,6 +144,10 @@ func (m *TuiViewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case streamClosedMsg:
 		if m.active != nil {
 			m.active.events = nil
+			m.active.streamClosed = true
+			if m.active.doneReceived {
+				return m.finalizeActiveStream()
+			}
 		}
 		return m, nil
 	case streamDoneMsg:
@@ -361,22 +368,13 @@ func (m *TuiViewModel) handleStreamDone(msg streamDoneMsg) (tea.Model, tea.Cmd) 
 		return m, nil
 	}
 
-	m.stopActiveStream()
-	if m.state == stateAborting {
-		// 不回滚，保留消息
-		m.logs = append(m.logs, NewNotice("用户取消了 agent loop，消息已保留。"))
-		m.state = stateIdle
-		m.refreshLogsViewportContent()
+	m.active.doneReceived = true
+	m.active.doneErr = msg.err
+	if !m.active.streamClosed {
 		return m, nil
 	}
 
-	if msg.err != nil {
-		m.logs = append(m.logs, NewError(msg.err.Error()))
-	}
-	m.logs = append(m.logs, NewBorder())
-	m.state = stateIdle
-	m.refreshLogsViewportContent()
-	return m, nil
+	return m.finalizeActiveStream()
 }
 
 func (m *TuiViewModel) startNewTurn(query string) (tea.Model, tea.Cmd) {
@@ -445,6 +443,32 @@ func (m *TuiViewModel) stopActiveStream() {
 		m.active.cancel()
 	}
 	m.active = nil
+}
+
+func (m *TuiViewModel) finalizeActiveStream() (tea.Model, tea.Cmd) {
+	if m.active == nil {
+		m.state = stateIdle
+		return m, nil
+	}
+
+	err := m.active.doneErr
+	if m.state == stateAborting {
+		// 不回滚，保留消息
+		m.logs = append(m.logs, NewNotice("用户取消了 agent loop，消息已保留。"))
+		m.stopActiveStream()
+		m.state = stateIdle
+		m.refreshLogsViewportContent()
+		return m, nil
+	}
+
+	m.stopActiveStream()
+	if err != nil {
+		m.logs = append(m.logs, NewError(err.Error()))
+	}
+	m.logs = append(m.logs, NewBorder())
+	m.state = stateIdle
+	m.refreshLogsViewportContent()
+	return m, nil
 }
 
 func (m *TuiViewModel) scrollUp(n int) {

--- a/ch09/tui/tui.go
+++ b/ch09/tui/tui.go
@@ -36,11 +36,14 @@ type activeStream struct {
 	cancel    context.CancelFunc
 	confirmCh chan ch09.ConfirmationAction
 
-	turnLogLen  int
-	reasonBody  int
-	contentBody int
-	policyBody  int // 当前策略 log entry 的索引
-	memoryBody  int // 当前记忆更新 log entry 的索引
+	turnLogLen   int
+	reasonBody   int
+	contentBody  int
+	policyBody   int // 当前策略 log entry 的索引
+	memoryBody   int // 当前记忆更新 log entry 的索引
+	streamClosed bool
+	doneReceived bool
+	doneErr      error
 }
 
 type TuiViewModel struct {
@@ -141,6 +144,10 @@ func (m *TuiViewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case streamClosedMsg:
 		if m.active != nil {
 			m.active.events = nil
+			m.active.streamClosed = true
+			if m.active.doneReceived {
+				return m.finalizeActiveStream()
+			}
 		}
 		return m, nil
 	case streamDoneMsg:
@@ -361,22 +368,13 @@ func (m *TuiViewModel) handleStreamDone(msg streamDoneMsg) (tea.Model, tea.Cmd) 
 		return m, nil
 	}
 
-	m.stopActiveStream()
-	if m.state == stateAborting {
-		// 不回滚，保留消息
-		m.logs = append(m.logs, NewNotice("用户取消了 agent loop，消息已保留。"))
-		m.state = stateIdle
-		m.refreshLogsViewportContent()
+	m.active.doneReceived = true
+	m.active.doneErr = msg.err
+	if !m.active.streamClosed {
 		return m, nil
 	}
 
-	if msg.err != nil {
-		m.logs = append(m.logs, NewError(msg.err.Error()))
-	}
-	m.logs = append(m.logs, NewBorder())
-	m.state = stateIdle
-	m.refreshLogsViewportContent()
-	return m, nil
+	return m.finalizeActiveStream()
 }
 
 func (m *TuiViewModel) startNewTurn(query string) (tea.Model, tea.Cmd) {
@@ -445,6 +443,32 @@ func (m *TuiViewModel) stopActiveStream() {
 		m.active.cancel()
 	}
 	m.active = nil
+}
+
+func (m *TuiViewModel) finalizeActiveStream() (tea.Model, tea.Cmd) {
+	if m.active == nil {
+		m.state = stateIdle
+		return m, nil
+	}
+
+	err := m.active.doneErr
+	if m.state == stateAborting {
+		// 不回滚，保留消息
+		m.logs = append(m.logs, NewNotice("用户取消了 agent loop，消息已保留。"))
+		m.stopActiveStream()
+		m.state = stateIdle
+		m.refreshLogsViewportContent()
+		return m, nil
+	}
+
+	m.stopActiveStream()
+	if err != nil {
+		m.logs = append(m.logs, NewError(err.Error()))
+	}
+	m.logs = append(m.logs, NewBorder())
+	m.state = stateIdle
+	m.refreshLogsViewportContent()
+	return m, nil
 }
 
 func (m *TuiViewModel) scrollUp(n int) {


### PR DESCRIPTION
## What changed
- delay TUI stream finalization until both the event channel is closed and the terminal completion signal is received
- apply the same fix to `ch04`, `ch05`, `ch06`, `ch08`, and `ch09`
- preserve each chapter's existing abort behavior while avoiding dropped tail events

## Why
The TUI could clear the active stream as soon as `streamDoneMsg` arrived, even if the final streamed UI events had already been queued but not yet processed. That could leave status lines such as context policy or memory update stuck in a running state, or drop the last bit of streamed output.

## Impact
- prevents stale `运行中...` status lines caused by event ordering races
- avoids losing final tail output from the stream
- keeps abort handling semantics unchanged across the affected chapters

## Validation
- `GOCACHE=/tmp/go-build-cache go test -v ./ch04/... ./ch05/... ./ch06/... ./ch08/... ./ch09/...`
