### PR TITLE
feat: add ch12 explicit planning chapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 *   **Language:** Go 1.24+
 *   **LLM Concepts:** Chat Completions API, SSE 流式传输, Function Calling, ReAct Agent Loop
-*   **Advanced AI:** 上下文工程, Memory 系统, Agentic RAG, 技能系统（Skills）
+*   **Advanced AI:** 上下文工程, Memory 系统, Agentic RAG, 技能系统（Skills）, 显式规划（TodoWrite）
 *   **System Design:** MCP 协议,  Guardrails 安全防护, Web 服务化
 *   **Engineering:** LLM 评测, 可观测性（Trace/Metrics/Log）
 
@@ -139,7 +139,19 @@
 
 ---
 
-### 第十二章：Agent 评测与自动化测试（LLM Eval）🚧
+### 第十二章：显式规划（TodoWrite 与 Nag Reminder）
+
+**目标**：让 Agent 在多步骤任务里显式维护当前计划，并在 Web 界面里可视化展示执行进度。
+
+*   **TodoWrite 工具**：让模型将当前任务计划写成结构化 todo 列表
+*   **Nag Reminder**：当 Agent 忘记写计划或长期不更新计划时，注入轻量提醒
+*   **最小状态机**：`pending / in_progress / completed` 三态足够表达当前进度
+*   **计划快照持久化**：将 todo 快照存入消息历史，支持刷新恢复与分支对话
+*   **Web 计划面板**：在聊天界面右侧展示当前 todo 列表
+
+---
+
+### 第十三章：Agent 评测与自动化测试（LLM Eval）🚧
 
 **目标**：摒弃"靠肉眼看效果"的黑盒测试，构建自动化评测流水线。
 
@@ -192,7 +204,7 @@ baby-agent/
 ├── ch09/           # ✅ 第九章：Agent 技能插件
 ├── ch10/           # ✅ 第十章：Web 服务化与 SSE 流式传输
 ├── ch11/           # 🚧 第十一章：Agent 可观测性（规划中）
-├── ch12/           # 🚧 第十二章：Agent 评测与自动化测试（规划中）
+├── ch12/           # ✅ 第十二章：显式规划（TodoWrite 与 Nag Reminder）
 ├── shared/         # 共享代码（配置、MCP 等）
 ├── .env            # 环境变量配置
 └── README.md       # 本文件
@@ -231,6 +243,9 @@ go run ./ch09/main
 
 # 第十章：Web 服务（监听 :8080）
 go run ./ch10/main
+
+# 第十二章：显式规划 Web 服务（监听 :8080）
+go run ./ch12/main
 ```
 
 第七章是独立的索引和工具实现，可参考 `ch07/README.md` 中的使用示例。

--- a/ch12/README.md
+++ b/ch12/README.md
@@ -1,0 +1,246 @@
+# 第十二章：显式规划（TodoWrite 与 Nag Reminder）
+
+欢迎来到第十二章！在第十章中，我们已经把 Agent 封装成了 Web 服务，浏览器也可以像 ChatGPT 一样和它流式对话。
+
+但新的问题也随之出现：**一旦任务稍微复杂一点，Agent 很容易“边做边忘”，做着做着就偏题了。**
+
+比如：
+
+- 明明要“先读代码、再修改、最后跑测试”，Agent 却直接开始乱改文件
+- 已经完成了第一步，但没有更新当前计划，后面很难判断它做到哪了
+- 页面刷新之后，用户看不到刚才那轮任务的计划快照
+
+本章要解决的就是这个问题：让 Agent 在 Web 界面里把“当前计划”显式写出来，并在计划失效时收到轻量提醒。
+
+> **本章的核心目标不是构建完整任务系统，而是让 Agent 在当前会话里“有计划地工作”。**
+
+---
+
+## 🎯 你将学到什么
+
+1. **显式规划**：为什么多步骤任务需要可见的 todo 列表
+2. **`todo_write` 工具**：如何让模型主动维护当前计划
+3. **Nag Reminder**：如何在不打断体验的情况下提醒 Agent 更新计划
+4. **计划快照持久化**：为什么 Web 场景下不能只把 todo 放在进程内存里
+5. **分支感知恢复**：如何让不同对话分支拥有各自的计划状态
+
+---
+
+## 🧠 为什么要做显式规划？
+
+普通的 tool-calling Agent 很擅长“下一步做什么”，但不擅长一直记住“整个任务要怎么推进”。
+
+对于这类请求：
+
+```text
+请先定位登录失败的原因，再修复它，最后补一条回归测试
+```
+
+如果没有显式计划，Agent 往往会出现三类问题：
+
+1. **漂移**：做了一两步之后偏离主目标
+2. **失忆**：明明已经完成了一步，但没有更新当前进度
+3. **不可见**：用户只能看到推理和工具调用，看不到“整体执行计划”
+
+所以本章新增一层“会话内规划状态”：
+
+- 当前有哪些 todo
+- 哪一项正在进行
+- 哪些项已经完成
+
+它不追求复杂，只追求**清晰、稳定、能恢复**。
+
+---
+
+## 🧱 本章实现的核心能力
+
+### 1. `todo_write`：显式写计划
+
+Agent 新增一个原生工具：
+
+```text
+todo_write
+```
+
+它的输入是**整份 todo 快照**，而不是增量 patch：
+
+```json
+{
+  "items": [
+    { "content": "Inspect login flow", "status": "completed" },
+    { "content": "Patch handler logic", "status": "in_progress" },
+    { "content": "Run regression tests", "status": "pending" }
+  ]
+}
+```
+
+这样设计有几个好处：
+
+- 模型更容易生成
+- 服务端更容易校验
+- 前端更容易渲染
+- 页面刷新后更容易恢复
+
+### 2. 最小状态机
+
+本章只保留 3 种状态：
+
+- `pending`
+- `in_progress`
+- `completed`
+
+并且限制：
+
+- 最多 8 条 todo
+- 最多只能有 1 条 `in_progress`
+- `content` 不能为空
+
+这足够讲清楚“计划如何推进”，但不会过早进入完整任务系统的复杂度。
+
+### 3. Nag Reminder：轻量提醒，不是强制中断
+
+提醒不是一个新工具，也不是前端弹窗。
+
+它是在 Agent loop 内部，按条件临时注入的一段软提醒：
+
+- 如果已经进入 tool loop，但还没有 todo，提醒它先写计划
+- 如果 todo 已经存在，但明显落后于当前执行进度，提醒它更新计划
+
+提醒是**本轮请求内临时生效**的，不会污染长期历史消息。
+
+### 4. 计划快照持久化
+
+在 TUI 里，把 todo 放在内存里就够了；但在 Web 场景里不够。
+
+因为：
+
+- 下一条消息是新的 HTTP 请求
+- 页面可能刷新
+- 对话还有分支
+
+所以本章把最新计划快照序列化到 `ChatMessage.PlanState` 中。这样下一轮请求开始时，就能沿祖先链找到最近一次计划快照，并恢复当前 planning state。
+
+### 5. Web 侧可视化
+
+本章前端在聊天区域右侧增加一个只读 todo 面板：
+
+- 流式收到 `todo_snapshot` 事件时，直接覆盖当前面板
+- 重新加载历史消息时，从最近一条消息的 `plan_state` 恢复
+- 不支持手工拖拽、编辑、排序
+
+这是一个**Agent 计划观察面板**，不是用户任务看板。
+
+---
+
+## 🗂 代码结构
+
+```text
+ch12/
+├── agent/
+│   ├── agent.go            # Agent loop + nag reminder + todo snapshot event
+│   ├── reminder.go         # 提醒触发逻辑
+│   ├── plan/
+│   │   ├── state.go        # PlanningState / PlanItem / PlanStatus
+│   │   └── manager.go      # todo 校验与整份快照替换
+│   └── tool/
+│       ├── bash.go
+│       ├── todo.go         # todo_write 工具
+│       └── tool.go
+├── server/
+│   ├── db.go               # ChatMessage 增加 PlanState
+│   ├── history.go          # 分支感知恢复 history 与 latest plan
+│   ├── service.go          # SSE 输出 todo_snapshot，保存最新快照
+│   └── controller.go
+├── vo/
+│   ├── sse.go              # SSEMessageVO 增加 plan_state
+│   └── vo.go               # ChatMessageVO 增加 plan_state
+└── main/
+    └── main.go
+```
+
+前端复用根目录的 `frontend/`，并在 legacy chat 流程中增加 `TodoPanel`。
+
+> 这里刻意没有把 planning state 直接接进 `assistant-ui` runtime。
+>
+> 原因很简单：本章的教学重点是显式规划本身，而不是 UI runtime 的二次封装。先用更直接的前端路径把核心原理讲清楚，后续再做更复杂的运行时整合更合适。
+
+---
+
+## ▶️ 运行方式
+
+### 1. 启动后端
+
+在项目根目录：
+
+```bash
+go run ./ch12/main
+```
+
+默认监听：
+
+```text
+http://localhost:8080
+```
+
+### 2. 启动前端
+
+```bash
+pnpm --dir frontend dev
+```
+
+打开浏览器访问 Vite 输出的本地地址即可。
+
+### 3. 建议测试的输入
+
+可以尝试这类多步骤任务：
+
+```text
+请先阅读当前仓库的 README，找出 ch12 还缺什么，再给出一个修改方案
+```
+
+或者：
+
+```text
+请先定位登录逻辑，再修复 bug，最后补测试
+```
+
+如果 Agent 进入多步执行，你应该能在右侧看到 todo 面板逐步出现并更新。
+
+---
+
+## ✅ 本章验证方式
+
+后端测试：
+
+```bash
+go test -v ./ch12/...
+```
+
+前端构建：
+
+```bash
+pnpm --dir frontend build
+```
+
+手工检查：
+
+1. 发起一个多步骤请求
+2. 确认右侧 `Current Plan` 面板出现
+3. 确认后续 `todo_write` 会更新当前项状态
+4. 刷新页面后确认计划仍能恢复
+5. 从旧消息分支继续对话时，确认计划跟着分支变化
+
+---
+
+## 🚧 本章刻意没做什么
+
+为了保持教学重点，本章**没有**实现：
+
+- `blocked / cancelled` 等更复杂状态
+- todo 排序规则
+- 用户直接编辑 todo
+- 后台任务与定时调度
+- 多 Agent 共用计划
+- 真正的任务系统 / 调度系统
+
+这些内容更适合后续做成“完整版规划”章节。

--- a/ch12/agent/agent.go
+++ b/ch12/agent/agent.go
@@ -1,0 +1,222 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/openai/openai-go/v3"
+
+	"babyagent/ch12/agent/plan"
+	"babyagent/ch12/agent/tool"
+	"babyagent/shared"
+)
+
+const SystemPrompt = `# BabyAgent
+
+You are BabyAgent, a helpful coding assistant.
+
+## Guidelines
+- State intent before tool calls, but NEVER predict or claim results before receiving them.
+- Before modifying a file, read it first. Do not assume files or directories exist.
+- If a tool call fails, analyze the error before retrying with a different approach.
+- Ask for clarification when the request is ambiguous.
+
+Reply directly with text for conversations.
+`
+
+type Agent struct {
+	model        string
+	client       openai.Client
+	nativeTools  map[tool.AgentTool]tool.Tool
+	systemPrompt string
+}
+
+func NewAgent(modelConf shared.ModelConfig, systemPrompt string, tools []tool.Tool) *Agent {
+	a := &Agent{
+		model:        modelConf.Model,
+		client:       shared.NewLLMClient(modelConf),
+		nativeTools:  make(map[tool.AgentTool]tool.Tool),
+		systemPrompt: systemPrompt,
+	}
+	for _, t := range tools {
+		a.nativeTools[t.ToolName()] = t
+	}
+	return a
+}
+
+func (a *Agent) Model() string {
+	return a.model
+}
+
+func (a *Agent) findTool(toolName string) (tool.Tool, bool) {
+	t, ok := a.nativeTools[toolName]
+	return t, ok
+}
+
+func (a *Agent) buildTools() []openai.ChatCompletionToolUnionParam {
+	tools := make([]openai.ChatCompletionToolUnionParam, 0, len(a.nativeTools))
+	for _, t := range a.nativeTools {
+		tools = append(tools, t.Info())
+	}
+	return tools
+}
+
+// executeTool 执行单个 tool call，返回 tool result 和错误。
+// tool 不存在时返回错误；Execute 失败时返回错误，result 为错误信息。
+func (a *Agent) executeTool(ctx context.Context, toolCall openai.ChatCompletionMessageToolCallUnion) (string, error) {
+	t, ok := a.findTool(toolCall.Function.Name)
+	if !ok {
+		return "", fmt.Errorf("tool not found: %s", toolCall.Function.Name)
+	}
+	return t.Execute(ctx, toolCall.Function.Arguments)
+}
+
+// RunResult 是 Agent 一轮运行的结果
+type RunResult struct {
+	Response string
+	Rounds   []shared.OpenAIMessage
+	Usage    openai.CompletionUsage
+	Plan     plan.PlanningState
+}
+
+// RunStreaming 执行 agent loop，通过 eventCh 流式输出，结束后返回 RunResult
+// history 是本会话之前所有 ChatMessage.Rounds 反序列化后的消息列表
+func (a *Agent) RunStreaming(ctx context.Context, history []openai.ChatCompletionMessageParamUnion, initialPlan plan.PlanningState, query string, eventCh chan<- StreamEvent) (RunResult, error) {
+	conversation := make([]openai.ChatCompletionMessageParamUnion, 0, len(history)+1)
+	conversation = append(conversation, history...)
+	conversation = append(conversation, openai.UserMessage(query))
+
+	roundMessages := []shared.OpenAIMessage{openai.UserMessage(query)}
+
+	var usage openai.CompletionUsage
+	var finalResponse string
+	planManager := plan.NewManager(initialPlan)
+	reminders := &reminderState{}
+	toolCallsThisTurn := 0
+	loopIndex := 0
+
+	for {
+		requestMessages := make([]openai.ChatCompletionMessageParamUnion, 0, len(conversation)+2)
+		requestMessages = append(requestMessages, openai.SystemMessage(a.systemPrompt))
+		if reminder := reminders.Next(planManager.State(), loopIndex, toolCallsThisTurn); reminder != "" {
+			requestMessages = append(requestMessages, openai.SystemMessage(reminder))
+		}
+		requestMessages = append(requestMessages, conversation...)
+
+		runTools := a.buildRunTools(planManager)
+		params := openai.ChatCompletionNewParams{
+			Model:         a.model,
+			Messages:      requestMessages,
+			Tools:         buildToolParams(runTools),
+			StreamOptions: openai.ChatCompletionStreamOptionsParam{IncludeUsage: openai.Bool(true)},
+		}
+
+		stream := a.client.Chat.Completions.NewStreaming(ctx, params)
+		acc := openai.ChatCompletionAccumulator{}
+
+		for stream.Next() {
+			chunk := stream.Current()
+			acc.AddChunk(chunk)
+
+			if len(chunk.Choices) > 0 {
+				deltaRaw := chunk.Choices[0].Delta
+				delta := deltaWithReasoning{}
+				_ = json.Unmarshal([]byte(deltaRaw.RawJSON()), &delta)
+
+				if delta.ReasoningContent != "" {
+					eventCh <- StreamEvent{Event: EventReasoning, ReasoningContent: delta.ReasoningContent}
+				}
+				if delta.Content != "" {
+					eventCh <- StreamEvent{Event: EventContent, Content: delta.Content}
+				}
+			}
+		}
+		if err := stream.Err(); err != nil {
+			eventCh <- StreamEvent{Event: EventError, Content: err.Error()}
+			return RunResult{}, err
+		}
+		if len(acc.Choices) == 0 {
+			break
+		}
+
+		usage = acc.Usage
+		message := acc.Choices[0].Message
+		assistantMsg := message.ToParam()
+		conversation = append(conversation, assistantMsg)
+		roundMessages = append(roundMessages, assistantMsg)
+
+		// 没有 tool call，结束 loop
+		if len(message.ToolCalls) == 0 {
+			finalResponse = message.Content
+			break
+		}
+
+		// 执行 tool calls
+		for _, toolCall := range message.ToolCalls {
+			toolCallsThisTurn++
+			eventCh <- StreamEvent{Event: EventToolCall, ToolCall: toolCall.Function.Name, ToolArguments: toolCall.Function.Arguments}
+
+			toolCtx := tool.WithTodoLoopIndex(ctx, loopIndex)
+			toolResult, err := executeTool(toolCtx, runTools, toolCall)
+			if err != nil {
+				toolResult = err.Error()
+				eventCh <- StreamEvent{Event: EventError, Content: toolResult}
+			}
+			if err == nil && toolCall.Function.Name == string(tool.AgentToolTodoWrite) {
+				currentPlan := planManager.State()
+				eventCh <- StreamEvent{Event: EventTodoSnap, PlanState: &currentPlan}
+			}
+			eventCh <- StreamEvent{Event: EventToolResult, ToolCall: toolCall.Function.Name, ToolResult: toolResult}
+
+			toolMsg := openai.ToolMessage(toolResult, toolCall.ID)
+			conversation = append(conversation, toolMsg)
+			roundMessages = append(roundMessages, toolMsg)
+		}
+		loopIndex++
+
+		// 检查 context 是否取消
+		select {
+		case <-ctx.Done():
+			return RunResult{Response: finalResponse}, ctx.Err()
+		default:
+		}
+	}
+
+	return RunResult{
+		Response: finalResponse,
+		Rounds:   roundMessages,
+		Usage:    usage,
+		Plan:     planManager.State(),
+	}, nil
+}
+
+type deltaWithReasoning struct {
+	Content          string `json:"content"`
+	ReasoningContent string `json:"reasoning_content"`
+}
+
+func (a *Agent) buildRunTools(planManager *plan.Manager) map[tool.AgentTool]tool.Tool {
+	runTools := make(map[tool.AgentTool]tool.Tool, len(a.nativeTools)+1)
+	for name, nativeTool := range a.nativeTools {
+		runTools[name] = nativeTool
+	}
+	runTools[tool.AgentToolTodoWrite] = tool.NewTodoWriteTool(planManager)
+	return runTools
+}
+
+func buildToolParams(tools map[tool.AgentTool]tool.Tool) []openai.ChatCompletionToolUnionParam {
+	params := make([]openai.ChatCompletionToolUnionParam, 0, len(tools))
+	for _, current := range tools {
+		params = append(params, current.Info())
+	}
+	return params
+}
+
+func executeTool(ctx context.Context, tools map[tool.AgentTool]tool.Tool, toolCall openai.ChatCompletionMessageToolCallUnion) (string, error) {
+	current, ok := tools[toolCall.Function.Name]
+	if !ok {
+		return "", fmt.Errorf("tool not found: %s", toolCall.Function.Name)
+	}
+	return current.Execute(ctx, toolCall.Function.Arguments)
+}

--- a/ch12/agent/plan/manager.go
+++ b/ch12/agent/plan/manager.go
@@ -1,0 +1,87 @@
+package plan
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+)
+
+const maxPlanItems = 8
+
+type Manager struct {
+	mu    sync.RWMutex
+	state PlanningState
+}
+
+func NewManager(initial PlanningState) *Manager {
+	return &Manager{state: cloneState(initial)}
+}
+
+func (m *Manager) State() PlanningState {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return cloneState(m.state)
+}
+
+func (m *Manager) ReplaceSnapshot(items []PlanItem, loopIndex int) (PlanningState, error) {
+	normalized, err := normalizeItems(items)
+	if err != nil {
+		return PlanningState{}, err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.state = PlanningState{
+		Items:           normalized,
+		Revision:        m.state.Revision + 1,
+		LastUpdatedLoop: loopIndex,
+	}
+	return cloneState(m.state), nil
+}
+
+func normalizeItems(items []PlanItem) ([]PlanItem, error) {
+	if len(items) > maxPlanItems {
+		return nil, fmt.Errorf("todo list must contain at most %d items", maxPlanItems)
+	}
+
+	normalized := make([]PlanItem, 0, len(items))
+	inProgress := 0
+	for _, item := range items {
+		content := strings.TrimSpace(item.Content)
+		if content == "" {
+			return nil, fmt.Errorf("todo item content cannot be empty")
+		}
+
+		status := PlanStatus(strings.TrimSpace(string(item.Status)))
+		switch status {
+		case PlanStatusPending, PlanStatusInProgress, PlanStatusCompleted:
+		default:
+			return nil, fmt.Errorf("invalid todo status: %s", item.Status)
+		}
+
+		if status == PlanStatusInProgress {
+			inProgress++
+			if inProgress > 1 {
+				return nil, fmt.Errorf("todo list can have at most one in_progress item")
+			}
+		}
+
+		normalized = append(normalized, PlanItem{
+			Content: content,
+			Status:  status,
+		})
+	}
+
+	return normalized, nil
+}
+
+func cloneState(state PlanningState) PlanningState {
+	items := make([]PlanItem, len(state.Items))
+	copy(items, state.Items)
+	return PlanningState{
+		Items:           items,
+		Revision:        state.Revision,
+		LastUpdatedLoop: state.LastUpdatedLoop,
+	}
+}

--- a/ch12/agent/plan/manager_test.go
+++ b/ch12/agent/plan/manager_test.go
@@ -1,0 +1,99 @@
+package plan
+
+import "testing"
+
+func TestManagerReplaceSnapshot_AllowsSingleInProgress(t *testing.T) {
+	m := NewManager(PlanningState{})
+
+	state, err := m.ReplaceSnapshot([]PlanItem{
+		{Content: "Inspect login flow", Status: PlanStatusCompleted},
+		{Content: "Patch handler", Status: PlanStatusInProgress},
+		{Content: "Run tests", Status: PlanStatusPending},
+	}, 3)
+	if err != nil {
+		t.Fatalf("ReplaceSnapshot() error = %v", err)
+	}
+
+	if got, want := len(state.Items), 3; got != want {
+		t.Fatalf("len(state.Items) = %d, want %d", got, want)
+	}
+	if got, want := state.Items[1].Status, PlanStatusInProgress; got != want {
+		t.Fatalf("state.Items[1].Status = %q, want %q", got, want)
+	}
+	if got, want := state.Revision, 1; got != want {
+		t.Fatalf("state.Revision = %d, want %d", got, want)
+	}
+	if got, want := state.LastUpdatedLoop, 3; got != want {
+		t.Fatalf("state.LastUpdatedLoop = %d, want %d", got, want)
+	}
+}
+
+func TestManagerReplaceSnapshot_RejectsMultipleInProgress(t *testing.T) {
+	m := NewManager(PlanningState{})
+
+	_, err := m.ReplaceSnapshot([]PlanItem{
+		{Content: "Inspect login flow", Status: PlanStatusInProgress},
+		{Content: "Patch handler", Status: PlanStatusInProgress},
+	}, 1)
+	if err == nil {
+		t.Fatal("ReplaceSnapshot() error = nil, want validation error")
+	}
+}
+
+func TestManagerReplaceSnapshot_RejectsBlankContent(t *testing.T) {
+	m := NewManager(PlanningState{})
+
+	_, err := m.ReplaceSnapshot([]PlanItem{
+		{Content: "", Status: PlanStatusPending},
+	}, 1)
+	if err == nil {
+		t.Fatal("ReplaceSnapshot() error = nil, want validation error")
+	}
+}
+
+func TestManagerReplaceSnapshot_AllowsClearPlan(t *testing.T) {
+	m := NewManager(PlanningState{
+		Items: []PlanItem{
+			{Content: "Inspect login flow", Status: PlanStatusCompleted},
+		},
+		Revision:        2,
+		LastUpdatedLoop: 4,
+	})
+
+	state, err := m.ReplaceSnapshot(nil, 5)
+	if err != nil {
+		t.Fatalf("ReplaceSnapshot() error = %v", err)
+	}
+	if got := len(state.Items); got != 0 {
+		t.Fatalf("len(state.Items) = %d, want 0", got)
+	}
+	if got, want := state.Revision, 3; got != want {
+		t.Fatalf("state.Revision = %d, want %d", got, want)
+	}
+	if got, want := state.LastUpdatedLoop, 5; got != want {
+		t.Fatalf("state.LastUpdatedLoop = %d, want %d", got, want)
+	}
+}
+
+func TestManagerReplaceSnapshot_IncrementsRevision(t *testing.T) {
+	m := NewManager(PlanningState{})
+
+	first, err := m.ReplaceSnapshot([]PlanItem{
+		{Content: "Inspect login flow", Status: PlanStatusPending},
+	}, 1)
+	if err != nil {
+		t.Fatalf("first ReplaceSnapshot() error = %v", err)
+	}
+	second, err := m.ReplaceSnapshot([]PlanItem{
+		{Content: "Inspect login flow", Status: PlanStatusCompleted},
+	}, 2)
+	if err != nil {
+		t.Fatalf("second ReplaceSnapshot() error = %v", err)
+	}
+	if got, want := first.Revision, 1; got != want {
+		t.Fatalf("first.Revision = %d, want %d", got, want)
+	}
+	if got, want := second.Revision, 2; got != want {
+		t.Fatalf("second.Revision = %d, want %d", got, want)
+	}
+}

--- a/ch12/agent/plan/state.go
+++ b/ch12/agent/plan/state.go
@@ -1,0 +1,20 @@
+package plan
+
+type PlanStatus string
+
+const (
+	PlanStatusPending    PlanStatus = "pending"
+	PlanStatusInProgress PlanStatus = "in_progress"
+	PlanStatusCompleted  PlanStatus = "completed"
+)
+
+type PlanItem struct {
+	Content string     `json:"content"`
+	Status  PlanStatus `json:"status"`
+}
+
+type PlanningState struct {
+	Items           []PlanItem `json:"items"`
+	Revision        int        `json:"revision"`
+	LastUpdatedLoop int        `json:"last_updated_loop"`
+}

--- a/ch12/agent/reminder.go
+++ b/ch12/agent/reminder.go
@@ -1,0 +1,61 @@
+package agent
+
+import (
+	"strings"
+
+	"babyagent/ch12/agent/plan"
+)
+
+const (
+	noTodoReminderText = "Reminder: You are in a multi-step tool workflow. Call todo_write now with a short todo list. Keep it concise and have at most one item in_progress."
+	staleTodoReminder  = "Reminder: Your todo list looks stale. Update it with todo_write so completed work is marked done and the current active step is in_progress."
+)
+
+type reminderState struct {
+	noTodoReminderSent bool
+	staleReminderSent  bool
+}
+
+func (r *reminderState) Next(state plan.PlanningState, loopIndex int, toolCallsThisTurn int) string {
+	if toolCallsThisTurn == 0 {
+		return ""
+	}
+
+	if len(state.Items) == 0 {
+		if r.noTodoReminderSent {
+			return ""
+		}
+		r.noTodoReminderSent = true
+		return noTodoReminderText
+	}
+
+	if planComplete(state) {
+		return ""
+	}
+
+	if r.staleReminderSent {
+		return ""
+	}
+
+	if loopIndex-state.LastUpdatedLoop < 2 {
+		return ""
+	}
+
+	r.staleReminderSent = true
+	return staleTodoReminder
+}
+
+func planComplete(state plan.PlanningState) bool {
+	if len(state.Items) == 0 {
+		return false
+	}
+	for _, item := range state.Items {
+		if strings.TrimSpace(item.Content) == "" {
+			continue
+		}
+		if item.Status != plan.PlanStatusCompleted {
+			return false
+		}
+	}
+	return true
+}

--- a/ch12/agent/reminder_test.go
+++ b/ch12/agent/reminder_test.go
@@ -1,0 +1,45 @@
+package agent
+
+import (
+	"testing"
+
+	"babyagent/ch12/agent/plan"
+)
+
+func TestReminderState_ShouldRemindWhenToolLoopStartsWithoutPlan(t *testing.T) {
+	r := &reminderState{}
+
+	got := r.Next(plan.PlanningState{}, 1, 1)
+	if got == "" {
+		t.Fatal("Next() = empty string, want missing-plan reminder")
+	}
+}
+
+func TestReminderState_ShouldRemindWhenPlanIsStale(t *testing.T) {
+	r := &reminderState{}
+
+	got := r.Next(plan.PlanningState{
+		Items: []plan.PlanItem{
+			{Content: "Inspect login flow", Status: plan.PlanStatusCompleted},
+			{Content: "Patch handler", Status: plan.PlanStatusInProgress},
+		},
+		Revision:        1,
+		LastUpdatedLoop: 0,
+	}, 2, 2)
+	if got == "" {
+		t.Fatal("Next() = empty string, want stale-plan reminder")
+	}
+}
+
+func TestReminderState_DoesNotRepeatReminderInSameTurn(t *testing.T) {
+	r := &reminderState{}
+
+	first := r.Next(plan.PlanningState{}, 1, 1)
+	second := r.Next(plan.PlanningState{}, 2, 2)
+	if first == "" {
+		t.Fatal("first Next() = empty string, want reminder")
+	}
+	if second != "" {
+		t.Fatalf("second Next() = %q, want empty string", second)
+	}
+}

--- a/ch12/agent/stream.go
+++ b/ch12/agent/stream.go
@@ -1,0 +1,23 @@
+package agent
+
+import "babyagent/ch12/agent/plan"
+
+const (
+	EventError      = "error"
+	EventReasoning  = "reasoning"
+	EventContent    = "content"
+	EventToolCall   = "tool_call"
+	EventToolResult = "tool_result"
+	EventTodoSnap   = "todo_snapshot"
+)
+
+// StreamEvent 是 agent 内部流式输出的事件类型，与传输层无关
+type StreamEvent struct {
+	Event            string
+	Content          string
+	ReasoningContent string
+	ToolCall         string
+	ToolArguments    string
+	ToolResult       string
+	PlanState        *plan.PlanningState
+}

--- a/ch12/agent/tool/bash.go
+++ b/ch12/agent/tool/bash.go
@@ -1,0 +1,63 @@
+package tool
+
+import (
+	"context"
+	"encoding/json"
+	"os/exec"
+	"runtime"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/shared"
+)
+
+type BashTool struct{}
+
+func NewBashTool() *BashTool {
+	return &BashTool{}
+}
+
+type BashToolParam struct {
+	Command string `json:"command"`
+}
+
+func (t *BashTool) ToolName() AgentTool {
+	return AgentToolBash
+}
+
+func (t *BashTool) Info() openai.ChatCompletionToolUnionParam {
+	return openai.ChatCompletionFunctionTool(shared.FunctionDefinitionParam{
+		Name:        string(AgentToolBash),
+		Description: openai.String("execute bash command"),
+		Parameters: openai.FunctionParameters{
+			"type": "object",
+			"properties": map[string]any{
+				"command": map[string]any{
+					"type":        "string",
+					"description": "the bash command to execute",
+				},
+			},
+			"required": []string{"command"},
+		},
+	})
+}
+
+func (t *BashTool) Execute(ctx context.Context, argumentsInJSON string) (string, error) {
+	p := BashToolParam{}
+	err := json.Unmarshal([]byte(argumentsInJSON), &p)
+	if err != nil {
+		return "", err
+	}
+
+	var cmd *exec.Cmd
+	if runtime.GOOS == "windows" {
+		cmd = exec.CommandContext(ctx, "cmd", "/C", p.Command)
+	} else {
+		cmd = exec.CommandContext(ctx, "sh", "-c", p.Command)
+	}
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return string(output), err
+	}
+	return string(output), nil
+}

--- a/ch12/agent/tool/todo.go
+++ b/ch12/agent/tool/todo.go
@@ -1,0 +1,104 @@
+package tool
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/shared"
+
+	"babyagent/ch12/agent/plan"
+)
+
+type TodoWriteTool struct {
+	manager *plan.Manager
+}
+
+func NewTodoWriteTool(manager *plan.Manager) *TodoWriteTool {
+	return &TodoWriteTool{manager: manager}
+}
+
+type TodoWriteParam struct {
+	Items []TodoWriteItem `json:"items"`
+}
+
+type TodoWriteItem struct {
+	Content string `json:"content"`
+	Status  string `json:"status"`
+}
+
+func (t *TodoWriteTool) ToolName() AgentTool {
+	return AgentToolTodoWrite
+}
+
+func (t *TodoWriteTool) Info() openai.ChatCompletionToolUnionParam {
+	return openai.ChatCompletionFunctionTool(shared.FunctionDefinitionParam{
+		Name:        string(AgentToolTodoWrite),
+		Description: openai.String("replace the current todo list for this conversation turn"),
+		Parameters: openai.FunctionParameters{
+			"type": "object",
+			"properties": map[string]any{
+				"items": map[string]any{
+					"type": "array",
+					"items": map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"content": map[string]any{
+								"type":        "string",
+								"description": "short description of the todo item",
+							},
+							"status": map[string]any{
+								"type":        "string",
+								"description": "pending, in_progress, or completed",
+								"enum":        []string{"pending", "in_progress", "completed"},
+							},
+						},
+						"required": []string{"content", "status"},
+					},
+				},
+			},
+			"required": []string{"items"},
+		},
+	})
+}
+
+type todoLoopIndexContextKey struct{}
+
+func WithTodoLoopIndex(ctx context.Context, loopIndex int) context.Context {
+	return context.WithValue(ctx, todoLoopIndexContextKey{}, loopIndex)
+}
+
+func todoLoopIndexFromContext(ctx context.Context) int {
+	value := ctx.Value(todoLoopIndexContextKey{})
+	loopIndex, ok := value.(int)
+	if !ok {
+		return 0
+	}
+	return loopIndex
+}
+
+func (t *TodoWriteTool) Execute(ctx context.Context, argumentsInJSON string) (string, error) {
+	var param TodoWriteParam
+	if err := json.Unmarshal([]byte(argumentsInJSON), &param); err != nil {
+		return "", err
+	}
+
+	items := make([]plan.PlanItem, 0, len(param.Items))
+	for _, item := range param.Items {
+		items = append(items, plan.PlanItem{
+			Content: item.Content,
+			Status:  plan.PlanStatus(item.Status),
+		})
+	}
+
+	state, err := t.manager.ReplaceSnapshot(items, todoLoopIndexFromContext(ctx))
+	if err != nil {
+		return "", err
+	}
+
+	data, err := json.Marshal(state)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}

--- a/ch12/agent/tool/todo_test.go
+++ b/ch12/agent/tool/todo_test.go
@@ -1,0 +1,61 @@
+package tool
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"babyagent/ch12/agent/plan"
+)
+
+func TestTodoWriteTool_ReplaceSnapshot(t *testing.T) {
+	m := plan.NewManager(plan.PlanningState{})
+	tool := NewTodoWriteTool(m)
+
+	result, err := tool.Execute(context.Background(), `{"items":[{"content":"Inspect login flow","status":"completed"},{"content":"Patch handler","status":"in_progress"}]}`)
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	state := m.State()
+	if got, want := len(state.Items), 2; got != want {
+		t.Fatalf("len(state.Items) = %d, want %d", got, want)
+	}
+	if got, want := state.Items[1].Status, plan.PlanStatusInProgress; got != want {
+		t.Fatalf("state.Items[1].Status = %q, want %q", got, want)
+	}
+
+	var returned plan.PlanningState
+	if err := json.Unmarshal([]byte(result), &returned); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if got, want := returned.Revision, 1; got != want {
+		t.Fatalf("returned.Revision = %d, want %d", got, want)
+	}
+}
+
+func TestTodoWriteTool_ReturnsValidationError(t *testing.T) {
+	m := plan.NewManager(plan.PlanningState{})
+	tool := NewTodoWriteTool(m)
+
+	_, err := tool.Execute(context.Background(), `{"items":[{"content":"","status":"pending"}]}`)
+	if err == nil {
+		t.Fatal("Execute() error = nil, want validation error")
+	}
+}
+
+func TestTodoWriteTool_AllowsClearPlan(t *testing.T) {
+	m := plan.NewManager(plan.PlanningState{})
+	tool := NewTodoWriteTool(m)
+
+	if _, err := tool.Execute(context.Background(), `{"items":[{"content":"Inspect login flow","status":"pending"}]}`); err != nil {
+		t.Fatalf("seed Execute() error = %v", err)
+	}
+	if _, err := tool.Execute(context.Background(), `{"items":[]}`); err != nil {
+		t.Fatalf("clear Execute() error = %v", err)
+	}
+
+	if got := len(m.State().Items); got != 0 {
+		t.Fatalf("len(m.State().Items) = %d, want 0", got)
+	}
+}

--- a/ch12/agent/tool/tool.go
+++ b/ch12/agent/tool/tool.go
@@ -1,0 +1,20 @@
+package tool
+
+import (
+	"context"
+
+	"github.com/openai/openai-go/v3"
+)
+
+type AgentTool = string
+
+const (
+	AgentToolBash      AgentTool = "bash"
+	AgentToolTodoWrite AgentTool = "todo_write"
+)
+
+type Tool interface {
+	ToolName() AgentTool
+	Info() openai.ChatCompletionToolUnionParam
+	Execute(ctx context.Context, argumentsInJSON string) (string, error)
+}

--- a/ch12/main/main.go
+++ b/ch12/main/main.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"github.com/joho/godotenv"
+
+	"babyagent/ch12/agent"
+	"babyagent/ch12/agent/tool"
+	"babyagent/ch12/server"
+	"babyagent/shared"
+	"babyagent/shared/log"
+)
+
+func main() {
+	_ = godotenv.Load()
+
+	appConf, err := shared.LoadAppConfig("config.json")
+	if err != nil {
+		log.Errorf("Failed to load config.json: %v", err)
+		panic(err)
+	}
+
+	db, err := server.InitDB("ch12.db")
+	if err != nil {
+		log.Errorf("Failed to initialize database: %v", err)
+		panic(err)
+	}
+
+	a := agent.NewAgent(appConf.LLMProviders.FrontModel, agent.SystemPrompt, []tool.Tool{tool.NewBashTool()})
+	s := server.NewServer(db, a)
+	router := server.NewRouter(s)
+
+	if err := router.Run(":8080"); err != nil {
+		log.Errorf("Server failed: %v", err)
+		panic(err)
+	}
+}

--- a/ch12/server/controller.go
+++ b/ch12/server/controller.go
@@ -1,0 +1,139 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"babyagent/ch12/agent"
+	"babyagent/ch12/vo"
+	"babyagent/shared/log"
+)
+
+func NewRouter(s *Server) *gin.Engine {
+	g := gin.Default()
+
+	api := g.Group("/api")
+	api.POST("/conversation", s.createConversation)
+	api.GET("/conversation", s.listConversations)
+	api.PATCH("/conversation/:conversation_id", s.renameConversation)
+	api.DELETE("/conversation/:conversation_id", s.deleteConversation)
+	api.POST("/conversation/:conversation_id/message", s.createMessage)
+	api.GET("/conversation/:conversation_id/message", s.listMessages)
+
+	return g
+}
+
+// POST /conversation
+func (s *Server) createConversation(c *gin.Context) {
+	var req vo.CreateConversationReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, vo.Err(400, err.Error()))
+		return
+	}
+
+	result, err := s.CreateConversation(req)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, vo.Err(500, err.Error()))
+		return
+	}
+
+	c.JSON(http.StatusOK, vo.OK(result))
+}
+
+// GET /conversation
+func (s *Server) listConversations(c *gin.Context) {
+	userID := c.Query("user_id")
+
+	result, err := s.ListConversations(userID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, vo.Err(500, err.Error()))
+		return
+	}
+
+	c.JSON(http.StatusOK, vo.OK(result))
+}
+
+// PATCH /conversation/:conversation_id
+func (s *Server) renameConversation(c *gin.Context) {
+	conversationID := c.Param("conversation_id")
+
+	var req vo.UpdateConversationReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, vo.Err(400, err.Error()))
+		return
+	}
+
+	result, err := s.RenameConversation(conversationID, req.Title)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, vo.Err(500, err.Error()))
+		return
+	}
+
+	c.JSON(http.StatusOK, vo.OK(result))
+}
+
+// DELETE /conversation/:conversation_id
+func (s *Server) deleteConversation(c *gin.Context) {
+	conversationID := c.Param("conversation_id")
+
+	if err := s.DeleteConversation(conversationID); err != nil {
+		c.JSON(http.StatusInternalServerError, vo.Err(500, err.Error()))
+		return
+	}
+
+	c.JSON(http.StatusOK, vo.OK(map[string]any{"conversation_id": conversationID}))
+}
+
+// GET /conversation/:conversation_id/message
+func (s *Server) listMessages(c *gin.Context) {
+	conversationID := c.Param("conversation_id")
+
+	result, err := s.ListMessages(conversationID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, vo.Err(500, err.Error()))
+		return
+	}
+
+	c.JSON(http.StatusOK, vo.OK(result))
+}
+
+// POST /conversation/:conversation_id/message
+// 创建新消息并 SSE 流式输出 agent 响应
+func (s *Server) createMessage(c *gin.Context) {
+	conversationID := c.Param("conversation_id")
+
+	var req vo.CreateMessageReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, vo.Err(400, err.Error()))
+		return
+	}
+
+	eventCh := make(chan vo.SSEMessageVO, 64)
+	c.Header("Content-Type", "text/event-stream")
+	c.Header("Cache-Control", "no-cache")
+	c.Header("Connection", "keep-alive")
+
+	go func() {
+		defer close(eventCh)
+		if err := s.CreateMessage(c.Request.Context(), conversationID, req, eventCh); err != nil {
+			errMsg := err.Error()
+			eventCh <- vo.SSEMessageVO{Event: agent.EventError, Content: &errMsg}
+			return
+		}
+	}()
+
+	for {
+		select {
+		case <-c.Request.Context().Done():
+			log.Warn("Server is shutting down. Exiting...")
+			return
+		case e, ok := <-eventCh:
+			if !ok {
+				return
+			}
+			c.SSEvent("message", e)
+			c.Writer.Flush()
+		}
+	}
+}

--- a/ch12/server/db.go
+++ b/ch12/server/db.go
@@ -1,0 +1,42 @@
+package server
+
+import (
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+type Conversation struct {
+	ConversationID string `gorm:"primaryKey"`
+	UserID         string `gorm:"index"`
+	Title          string
+	CreatedAt      int64
+}
+
+type ChatMessage struct {
+	MessageID       string `gorm:"primaryKey"`
+	UserID          string `gorm:"index"`
+	ConversationID  string `gorm:"index"`
+	ParentMessageID string
+
+	Query    string // 用户的原始提问
+	Response string // 模型的最终输出
+	Rounds   string // 用户提问到模型结束 tool loop 之间所有的 llm 请求，以 json 存储
+
+	Model     string // 使用的模型
+	Usage     string
+	PlanState string
+
+	CreatedAt int64
+}
+
+func InitDB(dsn string) (*gorm.DB, error) {
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	if err != nil {
+		return nil, err
+	}
+	err = db.AutoMigrate(&Conversation{}, &ChatMessage{})
+	if err != nil {
+		return nil, err
+	}
+	return db, nil
+}

--- a/ch12/server/history.go
+++ b/ch12/server/history.go
@@ -1,0 +1,82 @@
+package server
+
+import (
+	"encoding/json"
+
+	"babyagent/ch12/agent/plan"
+	"babyagent/shared"
+)
+
+// buildHistory 根据 parent_message_id 沿树向上追溯路径，
+// 将路径上每条消息的 rounds 拼接成 LLM history。
+// allMsgs 为该会话下的全部消息，parentMessageID 为本次请求的父消息 ID。
+func buildHistory(allMsgs []ChatMessage, parentMessageID string) []shared.OpenAIMessage {
+	if parentMessageID == "" {
+		return nil
+	}
+
+	// 构建 id -> message 索引
+	index := make(map[string]*ChatMessage, len(allMsgs))
+	for i := range allMsgs {
+		index[allMsgs[i].MessageID] = &allMsgs[i]
+	}
+
+	// 从 parentMessageID 向根节点追溯，收集路径（顺序：根 -> parent）
+	path := make([]*ChatMessage, 0)
+	cur := parentMessageID
+	for cur != "" {
+		msg, ok := index[cur]
+		if !ok {
+			break
+		}
+		path = append(path, msg)
+		cur = msg.ParentMessageID
+	}
+
+	// 反转：变为根 -> parent 顺序
+	for i, j := 0, len(path)-1; i < j; i, j = i+1, j-1 {
+		path[i], path[j] = path[j], path[i]
+	}
+
+	// 拼接每条消息的 rounds
+	history := make([]shared.OpenAIMessage, 0)
+	for _, msg := range path {
+		if msg.Rounds == "" {
+			continue
+		}
+		var rounds []shared.OpenAIMessage
+		if err := json.Unmarshal([]byte(msg.Rounds), &rounds); err != nil {
+			continue
+		}
+		history = append(history, rounds...)
+	}
+	return history
+}
+
+func findLatestPlanState(allMsgs []ChatMessage, parentMessageID string) plan.PlanningState {
+	if parentMessageID == "" {
+		return plan.PlanningState{}
+	}
+
+	index := make(map[string]*ChatMessage, len(allMsgs))
+	for i := range allMsgs {
+		index[allMsgs[i].MessageID] = &allMsgs[i]
+	}
+
+	cur := parentMessageID
+	for cur != "" {
+		msg, ok := index[cur]
+		if !ok {
+			break
+		}
+		if msg.PlanState != "" {
+			var state plan.PlanningState
+			if err := json.Unmarshal([]byte(msg.PlanState), &state); err == nil {
+				return state
+			}
+		}
+		cur = msg.ParentMessageID
+	}
+
+	return plan.PlanningState{}
+}

--- a/ch12/server/history_test.go
+++ b/ch12/server/history_test.go
@@ -1,0 +1,88 @@
+package server
+
+import (
+	"encoding/json"
+	"testing"
+
+	"babyagent/ch12/agent/plan"
+)
+
+func TestFindLatestPlanState_FollowsAncestorChain(t *testing.T) {
+	rootPlan := mustPlanJSON(t, plan.PlanningState{
+		Items: []plan.PlanItem{
+			{Content: "Inspect login flow", Status: plan.PlanStatusCompleted},
+		},
+		Revision:        1,
+		LastUpdatedLoop: 1,
+	})
+
+	all := []ChatMessage{
+		{MessageID: "root", ParentMessageID: "", PlanState: rootPlan},
+		{MessageID: "child", ParentMessageID: "root"},
+		{MessageID: "leaf", ParentMessageID: "child"},
+	}
+
+	got := findLatestPlanState(all, "leaf")
+	if got.Revision != 1 {
+		t.Fatalf("got.Revision = %d, want 1", got.Revision)
+	}
+	if len(got.Items) != 1 {
+		t.Fatalf("len(got.Items) = %d, want 1", len(got.Items))
+	}
+}
+
+func TestFindLatestPlanState_IgnoresSiblingBranchSnapshots(t *testing.T) {
+	rootPlan := mustPlanJSON(t, plan.PlanningState{
+		Items: []plan.PlanItem{
+			{Content: "Inspect login flow", Status: plan.PlanStatusPending},
+		},
+		Revision:        1,
+		LastUpdatedLoop: 0,
+	})
+	siblingPlan := mustPlanJSON(t, plan.PlanningState{
+		Items: []plan.PlanItem{
+			{Content: "Patch sibling branch", Status: plan.PlanStatusInProgress},
+		},
+		Revision:        2,
+		LastUpdatedLoop: 3,
+	})
+
+	all := []ChatMessage{
+		{MessageID: "root", ParentMessageID: "", PlanState: rootPlan},
+		{MessageID: "left", ParentMessageID: "root"},
+		{MessageID: "left-leaf", ParentMessageID: "left"},
+		{MessageID: "right", ParentMessageID: "root", PlanState: siblingPlan},
+	}
+
+	got := findLatestPlanState(all, "left-leaf")
+	if len(got.Items) != 1 {
+		t.Fatalf("len(got.Items) = %d, want 1", len(got.Items))
+	}
+	if got.Items[0].Content != "Inspect login flow" {
+		t.Fatalf("got.Items[0].Content = %q, want %q", got.Items[0].Content, "Inspect login flow")
+	}
+}
+
+func TestFindLatestPlanState_ReturnsEmptyWhenNoSnapshot(t *testing.T) {
+	all := []ChatMessage{
+		{MessageID: "root", ParentMessageID: ""},
+		{MessageID: "leaf", ParentMessageID: "root"},
+	}
+
+	got := findLatestPlanState(all, "leaf")
+	if got.Revision != 0 {
+		t.Fatalf("got.Revision = %d, want 0", got.Revision)
+	}
+	if len(got.Items) != 0 {
+		t.Fatalf("len(got.Items) = %d, want 0", len(got.Items))
+	}
+}
+
+func mustPlanJSON(t *testing.T, state plan.PlanningState) string {
+	t.Helper()
+	data, err := json.Marshal(state)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	return string(data)
+}

--- a/ch12/server/service.go
+++ b/ch12/server/service.go
@@ -1,0 +1,281 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+
+	"babyagent/ch12/agent"
+	"babyagent/ch12/agent/plan"
+	"babyagent/ch12/vo"
+	"babyagent/shared"
+	"babyagent/shared/log"
+)
+
+type Server struct {
+	db    *gorm.DB
+	agent *agent.Agent
+}
+
+func NewServer(db *gorm.DB, agent *agent.Agent) *Server {
+	return &Server{db: db, agent: agent}
+}
+
+func (s *Server) CreateConversation(req vo.CreateConversationReq) (vo.ConversationVO, error) {
+	conv := Conversation{
+		ConversationID: uuid.New().String(),
+		UserID:         req.UserID,
+		Title:          req.Title,
+		CreatedAt:      time.Now().Unix(),
+	}
+	if err := s.db.Create(&conv).Error; err != nil {
+		return vo.ConversationVO{}, err
+	}
+	return vo.ConversationVO{
+		ConversationID: conv.ConversationID,
+		UserID:         conv.UserID,
+		Title:          conv.Title,
+		CreatedAt:      conv.CreatedAt,
+	}, nil
+}
+
+func (s *Server) ListConversations(userID string) ([]vo.ConversationVO, error) {
+	var convs []Conversation
+	query := s.db.Order("created_at desc")
+	if userID != "" {
+		query = query.Where("user_id = ?", userID)
+	}
+	if err := query.Find(&convs).Error; err != nil {
+		return nil, err
+	}
+
+	result := make([]vo.ConversationVO, 0, len(convs))
+	for _, conv := range convs {
+		result = append(result, vo.ConversationVO{
+			ConversationID: conv.ConversationID,
+			UserID:         conv.UserID,
+			Title:          conv.Title,
+			CreatedAt:      conv.CreatedAt,
+		})
+	}
+	return result, nil
+}
+
+func (s *Server) RenameConversation(conversationID string, title string) (vo.ConversationVO, error) {
+	if err := s.db.Model(&Conversation{}).
+		Where("conversation_id = ?", conversationID).
+		Update("title", title).Error; err != nil {
+		return vo.ConversationVO{}, err
+	}
+
+	var conv Conversation
+	if err := s.db.First(&conv, "conversation_id = ?", conversationID).Error; err != nil {
+		return vo.ConversationVO{}, err
+	}
+
+	return vo.ConversationVO{
+		ConversationID: conv.ConversationID,
+		UserID:         conv.UserID,
+		Title:          conv.Title,
+		CreatedAt:      conv.CreatedAt,
+	}, nil
+}
+
+func (s *Server) DeleteConversation(conversationID string) error {
+	return s.db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("conversation_id = ?", conversationID).
+			Delete(&ChatMessage{}).Error; err != nil {
+			return err
+		}
+
+		return tx.Where("conversation_id = ?", conversationID).
+			Delete(&Conversation{}).Error
+	})
+}
+
+func (s *Server) ListMessages(conversationID string) ([]vo.ChatMessageVO, error) {
+	var msgs []ChatMessage
+	if err := s.db.Where("conversation_id = ?", conversationID).
+		Order("created_at asc").Find(&msgs).Error; err != nil {
+		return nil, err
+	}
+
+	result := make([]vo.ChatMessageVO, 0, len(msgs))
+	for _, msg := range msgs {
+		result = append(result, vo.ChatMessageVO{
+			MessageID:       msg.MessageID,
+			ConversationID:  msg.ConversationID,
+			ParentMessageID: msg.ParentMessageID,
+			Query:           msg.Query,
+			Response:        msg.Response,
+			Model:           msg.Model,
+			CreatedAt:       msg.CreatedAt,
+			Rounds:          parseRounds(msg.Rounds),
+			PlanState:       parsePlanState(msg.PlanState),
+		})
+	}
+	return result, nil
+}
+
+// CreateMessage 验证会话、构建历史、保存消息记录，并启动 agent 流式执行。
+func (s *Server) CreateMessage(ctx context.Context, conversationID string, req vo.CreateMessageReq, voCh chan<- vo.SSEMessageVO) error {
+	// 验证会话存在
+	var conv Conversation
+	if err := s.db.Where("conversation_id = ?", conversationID).First(&conv).Error; err != nil {
+		return err
+	}
+
+	// 从历史消息构建 history
+	var historyMsgs []ChatMessage
+	if err := s.db.Where("conversation_id = ?", conversationID).
+		Order("created_at asc").Find(&historyMsgs).Error; err != nil {
+		return err
+	}
+	history := buildHistory(historyMsgs, req.ParentMessageID)
+	initialPlan := findLatestPlanState(historyMsgs, req.ParentMessageID)
+
+	msgID := uuid.New().String()
+	createdAt := time.Now().Unix()
+
+	eventCh := make(chan agent.StreamEvent, 64)
+	defer func() {
+		close(eventCh)
+	}()
+
+	go func() {
+		for e := range eventCh {
+			voCh <- toSSEMessage(msgID, e)
+		}
+	}()
+
+	result, runErr := s.agent.RunStreaming(ctx, history, initialPlan, req.Query, eventCh)
+	if runErr != nil {
+		log.Warnf("run streaming error: %v", runErr)
+	}
+
+	roundsJSON, _ := json.Marshal(result.Rounds)
+	usageJSON, _ := json.Marshal(result.Usage)
+	planJSON, _ := marshalPlanState(result.Plan)
+	s.db.Create(&ChatMessage{
+		MessageID:       msgID,
+		UserID:          req.UserID,
+		ConversationID:  conversationID,
+		ParentMessageID: req.ParentMessageID,
+		Query:           req.Query,
+		Response:        result.Response,
+		Rounds:          string(roundsJSON),
+		Usage:           string(usageJSON),
+		PlanState:       planJSON,
+		Model:           s.agent.Model(),
+		CreatedAt:       createdAt,
+	})
+
+	return nil
+}
+
+func toSSEMessage(msgID string, e agent.StreamEvent) vo.SSEMessageVO {
+	msg := vo.SSEMessageVO{MessageID: msgID, Event: e.Event}
+	switch e.Event {
+	case agent.EventReasoning:
+		msg.ReasoningContent = &e.ReasoningContent
+	case agent.EventContent, agent.EventError:
+		msg.Content = &e.Content
+	case agent.EventToolCall:
+		msg.ToolCall = &e.ToolCall
+		msg.ToolArguments = &e.ToolArguments
+	case agent.EventToolResult:
+		msg.ToolCall = &e.ToolCall
+		msg.ToolResult = &e.ToolResult
+	case agent.EventTodoSnap:
+		msg.PlanState = toPlanningStateVO(e.PlanState)
+	}
+	return msg
+}
+
+func parsePlanState(raw string) *vo.PlanningStateVO {
+	if raw == "" {
+		return nil
+	}
+	var state plan.PlanningState
+	if err := json.Unmarshal([]byte(raw), &state); err != nil {
+		return nil
+	}
+	return toPlanningStateVO(&state)
+}
+
+func toPlanningStateVO(state *plan.PlanningState) *vo.PlanningStateVO {
+	if state == nil {
+		return nil
+	}
+	items := make([]vo.PlanItemVO, 0, len(state.Items))
+	for _, item := range state.Items {
+		items = append(items, vo.PlanItemVO{
+			Content: item.Content,
+			Status:  string(item.Status),
+		})
+	}
+	return &vo.PlanningStateVO{
+		Items:           items,
+		Revision:        state.Revision,
+		LastUpdatedLoop: state.LastUpdatedLoop,
+	}
+}
+
+func marshalPlanState(state plan.PlanningState) (string, error) {
+	if len(state.Items) == 0 && state.Revision == 0 && state.LastUpdatedLoop == 0 {
+		return "", nil
+	}
+	data, err := json.Marshal(state)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+// parseRounds 将存储的 rounds JSON 转换为前端友好的 RoundMessageVO 列表。
+func parseRounds(roundsJSON string) []vo.RoundMessageVO {
+	if roundsJSON == "" {
+		return nil
+	}
+	var msgs []shared.OpenAIMessage
+	if err := json.Unmarshal([]byte(roundsJSON), &msgs); err != nil {
+		return nil
+	}
+
+	result := make([]vo.RoundMessageVO, 0, len(msgs))
+	for _, m := range msgs {
+		switch {
+		case m.OfUser != nil:
+			// user 消息不需要展示
+			continue
+
+		case m.OfAssistant != nil:
+			a := m.OfAssistant
+			rv := vo.RoundMessageVO{Role: "assistant"}
+			if len(a.ToolCalls) > 0 {
+				for _, tc := range a.ToolCalls {
+					if tc.OfFunction != nil {
+						rv.ToolCalls = append(rv.ToolCalls, vo.ToolCallVO{
+							ID:        tc.OfFunction.ID,
+							Name:      tc.OfFunction.Function.Name,
+							Arguments: tc.OfFunction.Function.Arguments,
+						})
+					}
+				}
+				result = append(result, rv)
+			}
+
+		case m.OfTool != nil:
+			t := m.OfTool
+			result = append(result, vo.RoundMessageVO{
+				Role:    "tool",
+				ToolID:  t.ToolCallID,
+				Content: t.Content.OfString.Value,
+			})
+		}
+	}
+	return result
+}

--- a/ch12/server/service_test.go
+++ b/ch12/server/service_test.go
@@ -1,0 +1,169 @@
+package server
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"babyagent/ch12/agent"
+	"babyagent/ch12/agent/plan"
+	"babyagent/ch12/vo"
+)
+
+func TestRenameConversation_UpdatesTitle(t *testing.T) {
+	s := newTestServer(t)
+
+	created, err := s.CreateConversation(vo.CreateConversationReq{
+		UserID: "user_001",
+		Title:  "Old Title",
+	})
+	if err != nil {
+		t.Fatalf("CreateConversation() error = %v", err)
+	}
+
+	updated, err := s.RenameConversation(created.ConversationID, "New Title")
+	if err != nil {
+		t.Fatalf("RenameConversation() error = %v", err)
+	}
+
+	if updated.Title != "New Title" {
+		t.Fatalf("updated title = %q, want %q", updated.Title, "New Title")
+	}
+
+	var stored Conversation
+	if err := s.db.First(&stored, "conversation_id = ?", created.ConversationID).Error; err != nil {
+		t.Fatalf("load stored conversation: %v", err)
+	}
+
+	if stored.Title != "New Title" {
+		t.Fatalf("stored title = %q, want %q", stored.Title, "New Title")
+	}
+}
+
+func TestDeleteConversation_RemovesConversationAndMessages(t *testing.T) {
+	s := newTestServer(t)
+
+	created, err := s.CreateConversation(vo.CreateConversationReq{
+		UserID: "user_001",
+		Title:  "Delete Me",
+	})
+	if err != nil {
+		t.Fatalf("CreateConversation() error = %v", err)
+	}
+
+	if err := s.db.Create(&ChatMessage{
+		MessageID:       "msg-1",
+		UserID:          "user_001",
+		ConversationID:  created.ConversationID,
+		ParentMessageID: "",
+		Query:           "hello",
+		Response:        "world",
+		Model:           "test-model",
+		CreatedAt:       time.Now().Unix(),
+	}).Error; err != nil {
+		t.Fatalf("seed chat message: %v", err)
+	}
+
+	if err := s.DeleteConversation(created.ConversationID); err != nil {
+		t.Fatalf("DeleteConversation() error = %v", err)
+	}
+
+	var conversationCount int64
+	if err := s.db.Model(&Conversation{}).
+		Where("conversation_id = ?", created.ConversationID).
+		Count(&conversationCount).Error; err != nil {
+		t.Fatalf("count conversations: %v", err)
+	}
+	if conversationCount != 0 {
+		t.Fatalf("conversation count = %d, want 0", conversationCount)
+	}
+
+	var messageCount int64
+	if err := s.db.Model(&ChatMessage{}).
+		Where("conversation_id = ?", created.ConversationID).
+		Count(&messageCount).Error; err != nil {
+		t.Fatalf("count messages: %v", err)
+	}
+	if messageCount != 0 {
+		t.Fatalf("message count = %d, want 0", messageCount)
+	}
+}
+
+func TestListMessages_ParsesPlanState(t *testing.T) {
+	s := newTestServer(t)
+
+	planState, err := json.Marshal(vo.PlanningStateVO{
+		Items: []vo.PlanItemVO{
+			{Content: "Inspect login flow", Status: "completed"},
+			{Content: "Patch handler", Status: "in_progress"},
+		},
+		Revision:        2,
+		LastUpdatedLoop: 3,
+	})
+	if err != nil {
+		t.Fatalf("marshal plan state: %v", err)
+	}
+
+	if err := s.db.Create(&ChatMessage{
+		MessageID:       "msg-1",
+		UserID:          "user_001",
+		ConversationID:  "conv-1",
+		ParentMessageID: "",
+		Query:           "hello",
+		Response:        "world",
+		Model:           "test-model",
+		PlanState:       string(planState),
+		CreatedAt:       time.Now().Unix(),
+	}).Error; err != nil {
+		t.Fatalf("seed chat message: %v", err)
+	}
+
+	result, err := s.ListMessages("conv-1")
+	if err != nil {
+		t.Fatalf("ListMessages() error = %v", err)
+	}
+
+	if len(result) != 1 {
+		t.Fatalf("len(result) = %d, want 1", len(result))
+	}
+	if result[0].PlanState == nil {
+		t.Fatal("result[0].PlanState = nil, want parsed plan state")
+	}
+	if got, want := result[0].PlanState.Revision, 2; got != want {
+		t.Fatalf("result[0].PlanState.Revision = %d, want %d", got, want)
+	}
+}
+
+func TestToSSEMessage_MapsTodoSnapshot(t *testing.T) {
+	event := agent.StreamEvent{
+		Event: agent.EventTodoSnap,
+		PlanState: &plan.PlanningState{
+			Items: []plan.PlanItem{
+				{Content: "Inspect login flow", Status: plan.PlanStatusPending},
+			},
+			Revision:        1,
+			LastUpdatedLoop: 2,
+		},
+	}
+
+	got := toSSEMessage("msg-1", event)
+	if got.PlanState == nil {
+		t.Fatal("got.PlanState = nil, want plan state")
+	}
+	if got.Event != agent.EventTodoSnap {
+		t.Fatalf("got.Event = %q, want %q", got.Event, agent.EventTodoSnap)
+	}
+}
+
+func newTestServer(t *testing.T) *Server {
+	t.Helper()
+
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	db, err := InitDB(dbPath)
+	if err != nil {
+		t.Fatalf("InitDB() error = %v", err)
+	}
+
+	return NewServer(db, nil)
+}

--- a/ch12/vo/sse.go
+++ b/ch12/vo/sse.go
@@ -1,0 +1,20 @@
+package vo
+
+const (
+	SSETypeError      = "error"
+	SSETypeReasoning  = "reasoning"
+	SSETypeContent    = "content"
+	SSETypeToolCall   = "tool_call"
+	SSETypeToolResult = "tool_result"
+)
+
+type SSEMessageVO struct {
+	MessageID        string           `json:"message_id"`
+	Event            string           `json:"event"`
+	Content          *string          `json:"content,omitempty"`
+	ReasoningContent *string          `json:"reasoning_content,omitempty"`
+	ToolCall         *string          `json:"tool_call,omitempty"`
+	ToolArguments    *string          `json:"tool_arguments,omitempty"`
+	ToolResult       *string          `json:"tool_result,omitempty"`
+	PlanState        *PlanningStateVO `json:"plan_state,omitempty"`
+}

--- a/ch12/vo/vo.go
+++ b/ch12/vo/vo.go
@@ -1,0 +1,82 @@
+package vo
+
+// R 是统一的 JSON 响应包装
+type R struct {
+	Code int    `json:"code"`
+	Msg  string `json:"msg"`
+	Data any    `json:"data,omitempty"`
+}
+
+func OK(data any) R {
+	return R{Code: 0, Msg: "ok", Data: data}
+}
+
+func Err(code int, msg string) R {
+	return R{Code: code, Msg: msg}
+}
+
+// CreateConversationReq POST /conversation 请求体
+type CreateConversationReq struct {
+	UserID string `json:"user_id" binding:"required"`
+	Title  string `json:"title"`
+}
+
+// UpdateConversationReq PATCH /conversation/{id} 请求体
+type UpdateConversationReq struct {
+	Title string `json:"title" binding:"required"`
+}
+
+// CreateMessageReq POST /conversation/{id}/message 请求体
+type CreateMessageReq struct {
+	UserID          string `json:"user_id" binding:"required"`
+	Query           string `json:"query" binding:"required"`
+	ParentMessageID string `json:"parent_message_id"`
+}
+
+// ConversationVO GET /conversation 列表项
+type ConversationVO struct {
+	ConversationID string `json:"conversation_id"`
+	UserID         string `json:"user_id"`
+	Title          string `json:"title"`
+	CreatedAt      int64  `json:"created_at"`
+}
+
+// RoundMessageVO 是一条 LLM round 消息的精简视图
+type RoundMessageVO struct {
+	Role      string       `json:"role"`                 // user / assistant / tool
+	Content   string       `json:"content,omitempty"`    // 文本内容
+	ToolCalls []ToolCallVO `json:"tool_calls,omitempty"` // assistant 发起的 tool call
+	ToolName  string       `json:"tool_name,omitempty"`  // tool 消息的工具名
+	ToolID    string       `json:"tool_id,omitempty"`    // tool 消息对应的 call_id
+}
+
+// ToolCallVO 是一次 tool call 的精简视图
+type ToolCallVO struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"`
+}
+
+type PlanItemVO struct {
+	Content string `json:"content"`
+	Status  string `json:"status"`
+}
+
+type PlanningStateVO struct {
+	Items           []PlanItemVO `json:"items"`
+	Revision        int          `json:"revision"`
+	LastUpdatedLoop int          `json:"last_updated_loop"`
+}
+
+// ChatMessageVO GET /conversation/{id}/message 列表项
+type ChatMessageVO struct {
+	MessageID       string           `json:"message_id"`
+	ConversationID  string           `json:"conversation_id"`
+	ParentMessageID string           `json:"parent_message_id"`
+	Query           string           `json:"query"`
+	Response        string           `json:"response"`
+	Model           string           `json:"model"`
+	CreatedAt       int64            `json:"created_at"`
+	Rounds          []RoundMessageVO `json:"rounds,omitempty"`
+	PlanState       *PlanningStateVO `json:"plan_state,omitempty"`
+}

--- a/docs/superpowers/plans/2026-04-15-ch12-todowrite-web.md
+++ b/docs/superpowers/plans/2026-04-15-ch12-todowrite-web.md
@@ -1,0 +1,494 @@
+# ch12 TodoWrite Web Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `ch12` as a new web-based chapter that teaches explicit planning with `todo_write` and `nag reminder`, using a persisted plan snapshot and a visible todo panel.
+
+**Architecture:** Reuse `ch10`'s HTTP/SSE server shape, add a lightweight planning domain under `ch12/agent/plan`, persist the latest plan snapshot on each chat message, and render the current plan in the existing legacy web chat flow. Keep the planning model intentionally minimal: whole-list overwrite, three statuses, branch-aware recovery from message history.
+
+**Tech Stack:** Go, Gin, Gorm + SQLite, OpenAI-compatible tool calling, React + Vite, Server-Sent Events.
+
+---
+
+## Chunk 1: Backend Chapter Skeleton
+
+### Task 1: Create `ch12` baseline from the `ch10` service structure
+
+**Files:**
+- Create: `ch12/README.md`
+- Create: `ch12/main/main.go`
+- Create: `ch12/agent/agent.go`
+- Create: `ch12/agent/stream.go`
+- Create: `ch12/agent/tool/bash.go`
+- Create: `ch12/agent/tool/tool.go`
+- Create: `ch12/server/controller.go`
+- Create: `ch12/server/db.go`
+- Create: `ch12/server/history.go`
+- Create: `ch12/server/service.go`
+- Create: `ch12/server/service_test.go`
+- Create: `ch12/vo/vo.go`
+- Create: `ch12/vo/sse.go`
+- Modify: `README.md`
+
+- [ ] **Step 1: Copy the `ch10` server layout into a new `ch12` package tree**
+
+Replicate the `ch10` file structure so `ch12` starts from a known-good web chapter shape rather than mixing TUI-era files into a service chapter.
+
+- [ ] **Step 2: Update package names, imports, and entrypoint wiring**
+
+Set the `ch12` main package to initialize:
+
+```go
+db, err := server.InitDB("ch12.db")
+a := agent.NewAgent(appConf.LLMProviders.FrontModel, agent.SystemPrompt, []tool.Tool{tool.NewBashTool()})
+s := server.NewServer(db, a)
+router := server.NewRouter(s)
+```
+
+- [ ] **Step 3: Add a failing smoke build target**
+
+Run: `go test -v ./ch12/...`
+
+Expected: FAIL because planning files and new chapter wiring do not exist yet.
+
+- [ ] **Step 4: Fill in the minimum copied code until the chapter builds**
+
+Do not add planning behavior yet. Make `ch12` a clean copy baseline that still behaves like `ch10`.
+
+- [ ] **Step 5: Re-run the smoke target**
+
+Run: `go test -v ./ch12/...`
+
+Expected: PASS for the copied baseline tests or no-op test set.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ch12 README.md
+git commit -m "feat: scaffold ch12 web chapter"
+```
+
+## Chunk 2: Planning Domain
+
+### Task 2: Implement the planning state model and validation manager
+
+**Files:**
+- Create: `ch12/agent/plan/state.go`
+- Create: `ch12/agent/plan/manager.go`
+- Create: `ch12/agent/plan/manager_test.go`
+
+- [ ] **Step 1: Write failing tests for plan validation and snapshot replacement**
+
+Cover these behaviors in `ch12/agent/plan/manager_test.go`:
+
+```go
+func TestManagerReplaceSnapshot_AllowsSingleInProgress(t *testing.T)
+func TestManagerReplaceSnapshot_RejectsMultipleInProgress(t *testing.T)
+func TestManagerReplaceSnapshot_RejectsBlankContent(t *testing.T)
+func TestManagerReplaceSnapshot_AllowsClearPlan(t *testing.T)
+func TestManagerReplaceSnapshot_IncrementsRevision(t *testing.T)
+```
+
+- [ ] **Step 2: Run the focused plan tests**
+
+Run: `go test -v ./ch12/agent/plan`
+
+Expected: FAIL with missing types or methods like `PlanningState`, `ReplaceSnapshot`, or `PlanStatusInProgress`.
+
+- [ ] **Step 3: Implement the minimal state model**
+
+Add:
+
+```go
+type PlanStatus string
+type PlanItem struct { Content string; Status PlanStatus }
+type PlanningState struct { Items []PlanItem; Revision int; LastUpdatedLoop int }
+```
+
+Implement manager rules:
+
+- content non-empty
+- max 8 items
+- statuses limited to `pending`, `in_progress`, `completed`
+- at most one `in_progress`
+- empty list allowed
+
+- [ ] **Step 4: Implement whole-list replacement**
+
+Expose one manager method with behavior equivalent to:
+
+```go
+func (m *Manager) ReplaceSnapshot(items []PlanItem, loopIndex int) (PlanningState, error)
+```
+
+It should normalize input, overwrite the whole list, increment revision, and update `LastUpdatedLoop`.
+
+- [ ] **Step 5: Re-run the focused tests**
+
+Run: `go test -v ./ch12/agent/plan`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ch12/agent/plan
+git commit -m "feat: add ch12 planning state manager"
+```
+
+### Task 3: Add the `todo_write` tool on top of the planning manager
+
+**Files:**
+- Create: `ch12/agent/tool/todo.go`
+- Create: `ch12/agent/tool/todo_test.go`
+- Modify: `ch12/agent/tool/tool.go`
+
+- [ ] **Step 1: Write failing tool tests**
+
+Add tests that prove:
+
+```go
+func TestTodoWriteTool_ReplaceSnapshot(t *testing.T)
+func TestTodoWriteTool_ReturnsValidationError(t *testing.T)
+func TestTodoWriteTool_AllowsClearPlan(t *testing.T)
+```
+
+The tests should verify both manager mutation and returned tool result content.
+
+- [ ] **Step 2: Run the focused tool tests**
+
+Run: `go test -v ./ch12/agent/tool`
+
+Expected: FAIL because `todo_write` is not registered.
+
+- [ ] **Step 3: Implement the tool schema and execution**
+
+Add a tool with:
+
+```go
+Name: "todo_write"
+Parameters:
+{
+  "items": [{ "content": "...", "status": "pending|in_progress|completed" }]
+}
+```
+
+`Execute` should parse JSON, call the manager, and return the normalized snapshot as JSON text.
+
+- [ ] **Step 4: Register the tool name in the tool registry**
+
+Update the tool constants and interfaces so `todo_write` is a first-class native tool.
+
+- [ ] **Step 5: Re-run the tool package tests**
+
+Run: `go test -v ./ch12/agent/tool`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ch12/agent/tool
+git commit -m "feat: add todo_write tool for ch12"
+```
+
+## Chunk 3: Agent Loop Integration
+
+### Task 4: Integrate planning state and todo snapshot events into the agent loop
+
+**Files:**
+- Modify: `ch12/agent/agent.go`
+- Create: `ch12/agent/agent_test.go`
+- Modify: `ch12/agent/stream.go`
+- Modify: `ch12/vo/sse.go`
+- Modify: `ch12/vo/vo.go`
+
+- [ ] **Step 1: Write failing agent tests for todo snapshot emission**
+
+Add tests that prove:
+
+```go
+func TestRunStreaming_EmitsTodoSnapshotAfterTodoWrite(t *testing.T)
+func TestRunStreaming_UsesExistingPlanState(t *testing.T)
+```
+
+Stub the tool or LLM boundary as narrowly as possible so the tests target event emission and state mutation, not external API behavior.
+
+- [ ] **Step 2: Write failing tests for nag reminder decisions**
+
+Add focused tests like:
+
+```go
+func TestReminderState_ShouldRemindWhenToolLoopStartsWithoutPlan(t *testing.T)
+func TestReminderState_ShouldRemindWhenPlanIsStale(t *testing.T)
+func TestReminderState_DoesNotRepeatReminderInSameTurn(t *testing.T)
+```
+
+- [ ] **Step 3: Run the focused agent tests**
+
+Run: `go test -v ./ch12/agent/...`
+
+Expected: FAIL with missing reminder state or todo event support.
+
+- [ ] **Step 4: Extend the run state to carry planning state**
+
+Pass a current `PlanningState` into `RunStreaming`, maintain per-turn counters such as:
+
+```go
+loopIndex
+toolCallsThisTurn
+noTodoReminderSent
+staleTodoReminderSent
+```
+
+- [ ] **Step 5: Emit a full snapshot event after successful `todo_write`**
+
+Add a new stream event:
+
+```go
+const EventTodoSnapshot = "todo_snapshot"
+```
+
+and include:
+
+```go
+PlanState *plan.PlanningState
+```
+
+in the stream payload or equivalent VO.
+
+- [ ] **Step 6: Inject loop-local reminder text instead of durable messages**
+
+Before each LLM call, conditionally append a temporary reminder message to the request-only message slice when:
+
+- tool loop has started with no plan
+- plan is stale relative to execution progress
+
+Do not persist reminder messages into stored rounds.
+
+- [ ] **Step 7: Re-run the focused agent tests**
+
+Run: `go test -v ./ch12/agent/...`
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add ch12/agent ch12/vo
+git commit -m "feat: integrate planning state into ch12 agent loop"
+```
+
+## Chunk 4: Server Persistence and Recovery
+
+### Task 5: Persist plan snapshots on chat messages and recover them by branch
+
+**Files:**
+- Modify: `ch12/server/db.go`
+- Modify: `ch12/server/history.go`
+- Modify: `ch12/server/service.go`
+- Create: `ch12/server/history_test.go`
+- Modify: `ch12/server/service_test.go`
+- Modify: `ch12/vo/vo.go`
+
+- [ ] **Step 1: Write failing history tests for plan recovery**
+
+Add tests like:
+
+```go
+func TestFindLatestPlanState_FollowsAncestorChain(t *testing.T)
+func TestFindLatestPlanState_IgnoresSiblingBranchSnapshots(t *testing.T)
+func TestFindLatestPlanState_ReturnsEmptyWhenNoSnapshot(t *testing.T)
+```
+
+- [ ] **Step 2: Write failing service tests for persisted plan state**
+
+Extend `service_test.go` to prove:
+
+```go
+func TestCreateMessage_SavesLatestPlanSnapshot(t *testing.T)
+func TestListMessages_ReturnsPlanState(t *testing.T)
+```
+
+Use seeded `ChatMessage` rows where needed.
+
+- [ ] **Step 3: Run the focused server tests**
+
+Run: `go test -v ./ch12/server`
+
+Expected: FAIL because `ChatMessage` has no `PlanState` and history recovery does not exist.
+
+- [ ] **Step 4: Add `PlanState` storage to the DB model**
+
+Extend `ChatMessage` with:
+
+```go
+PlanState string
+```
+
+and let AutoMigrate create the new column.
+
+- [ ] **Step 5: Add branch-aware plan recovery helpers**
+
+Implement a helper with behavior equivalent to:
+
+```go
+func findLatestPlanState(allMsgs []ChatMessage, parentMessageID string) *plan.PlanningState
+```
+
+It should walk the same ancestor path logic as history reconstruction and return the nearest saved snapshot.
+
+- [ ] **Step 6: Save the latest snapshot at the end of each run**
+
+When `CreateMessage` finishes:
+
+- serialize current `PlanningState`
+- save it into `ChatMessage.PlanState`
+- expose the parsed value on `ChatMessageVO`
+
+- [ ] **Step 7: Re-run the focused server tests**
+
+Run: `go test -v ./ch12/server`
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add ch12/server ch12/vo
+git commit -m "feat: persist and recover ch12 plan snapshots"
+```
+
+## Chunk 5: Web UI
+
+### Task 6: Expose todo snapshots to the legacy web chat flow
+
+**Files:**
+- Modify: `frontend/src/App.tsx`
+- Modify: `frontend/src/api.ts`
+- Modify: `frontend/src/components/ChatPanel.tsx`
+- Create: `frontend/src/components/TodoPanel.tsx`
+- Modify: `frontend/src/index.css`
+
+- [ ] **Step 1: Write the smallest frontend proof target**
+
+Run: `pnpm --dir frontend build`
+
+Expected: PASS before edits so later failures are attributable to the todo panel changes.
+
+- [ ] **Step 2: Extend the frontend API types**
+
+Add:
+
+```ts
+export interface PlanItem { content: string; status: 'pending' | 'in_progress' | 'completed' }
+export interface PlanningState { items: PlanItem[]; revision: number; last_updated_loop: number }
+```
+
+Then extend:
+
+- `SSEMessageVO` with `event: 'todo_snapshot'`
+- `ChatMessageVO` with optional `plan_state`
+
+- [ ] **Step 3: Add a dedicated `TodoPanel` component**
+
+Render:
+
+- empty state when `plan_state` is missing or empty
+- active item highlight for `in_progress`
+- simple grouped or color-coded rows for completed vs pending
+
+Keep it read-only.
+
+- [ ] **Step 4: Integrate the panel into the legacy chat layout**
+
+Change `frontend/src/App.tsx` so `ch12` uses the legacy app path instead of the assistant-ui path. Keep the reason explicit in code comments: the chapter needs direct access to planning snapshots without adding assistant-ui-specific runtime plumbing.
+
+- [ ] **Step 5: Teach `ChatPanel` to track the latest snapshot**
+
+Initialize from fetched message history, then on SSE:
+
+- replace local plan state when `event === 'todo_snapshot'`
+- keep the latest snapshot visible during streaming
+- preserve the panel after stream completion
+
+- [ ] **Step 6: Re-run the frontend build**
+
+Run: `pnpm --dir frontend build`
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/App.tsx frontend/src/api.ts frontend/src/components/ChatPanel.tsx frontend/src/components/TodoPanel.tsx frontend/src/index.css
+git commit -m "feat: add todo panel to ch12 web UI"
+```
+
+## Chunk 6: Chapter Documentation and End-to-End Verification
+
+### Task 7: Document the chapter and verify the end-to-end flow
+
+**Files:**
+- Modify: `ch12/README.md`
+- Modify: `README.md`
+
+- [ ] **Step 1: Write the chapter README around the implemented behavior**
+
+Explain:
+
+- why agents drift on multi-step tasks
+- what `todo_write` does
+- what `nag reminder` does
+- why snapshots are persisted on `ChatMessage`
+- why the web UI uses the legacy chat flow for this chapter
+
+- [ ] **Step 2: Update the project root README**
+
+Add `ch12` to:
+
+- chapter list
+- learning path
+- quick start commands
+
+- [ ] **Step 3: Run the targeted backend verification**
+
+Run: `go test -v ./ch12/...`
+
+Expected: PASS.
+
+- [ ] **Step 4: Run the frontend verification**
+
+Run: `pnpm --dir frontend build`
+
+Expected: PASS.
+
+- [ ] **Step 5: Run a manual end-to-end smoke test**
+
+Start backend:
+
+```bash
+go run ./ch12/main
+```
+
+Start frontend:
+
+```bash
+pnpm --dir frontend dev
+```
+
+Manual checks:
+
+- create a conversation
+- send a multi-step coding request
+- confirm `todo_snapshot` appears in the panel
+- confirm the panel updates after later `todo_write`
+- refresh the page and confirm the latest plan is restored
+- branch from an older message and confirm the panel follows that branch
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ch12/README.md README.md
+git commit -m "docs: document ch12 explicit planning chapter"
+```

--- a/docs/superpowers/specs/2026-04-15-ch12-todowrite-web-design.md
+++ b/docs/superpowers/specs/2026-04-15-ch12-todowrite-web-design.md
@@ -1,0 +1,377 @@
+# ch12 TodoWrite Web Design
+
+## Goal
+
+Add a new `ch12` chapter that teaches session-scoped planning for an agent:
+
+- expose an explicit todo list through a `todo_write` tool
+- add a lightweight nag reminder when the agent drifts or forgets to update the plan
+- render the current plan in the existing web UI instead of the TUI
+
+This chapter should explain "visible execution planning", not a full task system.
+
+## Scope
+
+`ch12` is built on top of the ideas from `ch03`, but its runtime and UI should reuse the web architecture from `ch10`.
+
+In scope:
+
+- session-scoped todo state
+- minimal plan state machine: `pending / in_progress / completed`
+- `todo_write` tool with whole-list overwrite semantics
+- nag reminders injected into the current loop
+- SSE event for plan snapshots
+- web UI panel for the latest todo snapshot
+- branch-aware plan recovery through existing message history
+
+Out of scope:
+
+- background tasks
+- persistent task scheduler
+- multi-agent coordination
+- advanced status types like `blocked` or `cancelled`
+- sorting rules beyond keeping the list as-written
+- standalone `plan` database tables
+
+## Chapter Positioning
+
+Suggested narrative:
+
+- `ch03`: make the agent's reasoning visible
+- `ch12`: make the agent's execution plan visible
+
+This keeps `ch12` focused on "what the agent intends to do next and what it already finished".
+
+## High-Level Architecture
+
+`ch12` should have three layers:
+
+1. Agent planning layer
+   - maintains current planning state during a run
+   - exposes `todo_write`
+   - decides when to inject nag reminders
+2. Service persistence layer
+   - stores the latest plan snapshot alongside each chat message
+   - rebuilds plan state from the nearest ancestor message with a saved snapshot
+3. Web presentation layer
+   - listens for `todo_snapshot` SSE events
+   - renders the current todo list in a right-side plan panel
+
+The design should prefer full snapshots over incremental patches across all boundaries.
+
+## Backend Design
+
+### Directory Layout
+
+Suggested `ch12` layout:
+
+```text
+ch12/
+  README.md
+  main/main.go
+  agent/
+    agent.go
+    stream.go
+    plan/
+      manager.go
+      state.go
+    tool/
+      bash.go
+      todo.go
+      tool.go
+  server/
+    controller.go
+    db.go
+    history.go
+    service.go
+  vo/
+    sse.go
+    vo.go
+```
+
+This mirrors the service-style structure already used in `ch10`, while isolating planning logic under `agent/plan`.
+
+### Plan Data Structures
+
+Minimal planning model:
+
+```go
+type PlanStatus string
+
+const (
+	PlanStatusPending    PlanStatus = "pending"
+	PlanStatusInProgress PlanStatus = "in_progress"
+	PlanStatusCompleted  PlanStatus = "completed"
+)
+
+type PlanItem struct {
+	Content string     `json:"content"`
+	Status  PlanStatus `json:"status"`
+}
+
+type PlanningState struct {
+	Items           []PlanItem `json:"items"`
+	Revision        int        `json:"revision"`
+	LastUpdatedLoop int        `json:"last_updated_loop"`
+}
+```
+
+Rules:
+
+- `content` must be non-empty
+- maximum 8 items
+- at most one `in_progress`
+- unknown status is invalid
+- empty list is allowed and means "clear plan"
+
+### `todo_write` Tool
+
+Tool name:
+
+```text
+todo_write
+```
+
+Request shape:
+
+```go
+type TodoWriteParam struct {
+	Items []TodoWriteItem `json:"items"`
+}
+
+type TodoWriteItem struct {
+	Content string `json:"content"`
+	Status  string `json:"status"`
+}
+```
+
+Behavior:
+
+- the input fully replaces the current plan
+- validation happens in the plan manager
+- successful writes increment `Revision`
+- successful writes update `LastUpdatedLoop`
+- the tool returns a short success string plus the normalized plan snapshot
+
+Why whole-list overwrite:
+
+- easier for the model to generate
+- easier to validate
+- easier to stream to the frontend
+- easier to recover from history
+
+### Nag Reminder Logic
+
+Nag reminders should be temporary, loop-local instructions injected before the next LLM call. They should not be stored as durable conversation messages.
+
+Trigger 1: missing plan
+
+- current user turn has already entered tool loop
+- at least one tool call has happened
+- no plan exists yet
+- reminder has not already been sent in this turn
+
+Reminder goal:
+
+- ask the model to call `todo_write`
+- keep the list short
+- keep at most one item `in_progress`
+
+Trigger 2: stale plan
+
+- a plan exists
+- multiple execution steps have happened since the last plan update
+- reminder has not already been sent in this turn
+
+Reminder goal:
+
+- update completed items
+- move the next active item to `in_progress`
+- keep the plan aligned with actual progress
+
+Do not remind:
+
+- for single-turn plain answers with no tool usage
+- right after a fresh todo update
+- when the plan is already complete
+- once the loop is obviously ending
+
+Per-turn limits:
+
+- at most one "missing plan" reminder
+- at most one "stale plan" reminder
+
+Suggested per-turn counters:
+
+- `loopIndex`
+- `toolCallsThisTurn`
+- `noTodoReminderSent`
+- `staleTodoReminderSent`
+
+## Persistence Design
+
+Web UI requires plan recovery across requests, so the latest plan snapshot cannot live only in memory.
+
+### Message Storage
+
+Reuse the existing `ChatMessage` model pattern from `ch10` and add one optional field:
+
+```go
+PlanState string
+```
+
+This field stores serialized `PlanningState` JSON for the latest plan snapshot at the end of that message run.
+
+Design choice:
+
+- do not create a separate `plans` table in `ch12`
+- keep the plan attached to the message branch where it was produced
+
+This makes plan recovery naturally branch-aware.
+
+### History Recovery
+
+When handling a new request:
+
+1. walk the message ancestor path using existing branch logic
+2. find the nearest ancestor message containing non-empty `PlanState`
+3. unmarshal it into the current `PlanningState`
+4. pass that planning state into the next agent run
+
+This gives each conversation branch its own visible plan history without introducing a full task database.
+
+## SSE and API Design
+
+### New SSE Event
+
+Add a new SSE event type:
+
+```text
+todo_snapshot
+```
+
+Payload fields:
+
+- `message_id`
+- `event`
+- `plan_state`
+
+Where `plan_state` is the full current snapshot:
+
+```json
+{
+  "items": [
+    { "content": "Inspect login flow", "status": "completed" },
+    { "content": "Patch handler logic", "status": "in_progress" },
+    { "content": "Run regression tests", "status": "pending" }
+  ],
+  "revision": 2,
+  "last_updated_loop": 3
+}
+```
+
+Emission rule:
+
+- emit immediately after every successful `todo_write`
+
+This gives the frontend a simple "latest snapshot wins" model.
+
+### Message API
+
+Two backend output changes are needed:
+
+1. SSE stream includes `todo_snapshot`
+2. message list response includes the saved `plan_state` for each message, or at minimum for the latest message in the branch
+
+Preferred approach:
+
+- add optional `plan_state` to `ChatMessageVO`
+- frontend derives the latest plan from the newest loaded message
+
+## Frontend Design
+
+### Layout
+
+Use the existing web app and add a plan panel to the right side of the chat area.
+
+Recommended structure:
+
+```text
+Sidebar | Chat Thread | Todo Panel
+```
+
+The todo panel should show:
+
+- chapter title or label, e.g. "Current Plan"
+- items grouped visually by status
+- one active `in_progress` item highlighted
+- empty state when no plan exists yet
+
+### State Model
+
+Frontend keeps only one current snapshot:
+
+- initialize from loaded message history
+- replace it whenever a new `todo_snapshot` SSE event arrives
+- clear or switch it when changing conversations or branches
+
+No client-side patching is needed.
+
+### Visual Direction
+
+Keep the UI simple and instructional:
+
+- compact card panel
+- no drag/drop
+- no inline editing by user
+- no status badges beyond minimal color coding
+
+The panel is a teaching aid for the agent's plan, not a user-managed task board.
+
+## README Positioning
+
+`ch12/README.md` should explain:
+
+1. why agents drift on multi-step tasks
+2. why visible planning helps
+3. why snapshots are easier than patches for a teaching project
+4. why web UI needs persisted plan recovery
+
+Suggested chapter title:
+
+```text
+第十二章：显式规划（TodoWrite 与 Nag Reminder）
+```
+
+## Testing Strategy
+
+Minimum test targets:
+
+- plan manager validation rules
+- `todo_write` whole-list replacement behavior
+- nag reminder trigger logic
+- plan recovery from ancestor message history
+- SSE serialization for `todo_snapshot`
+
+Frontend verification can start with manual checks:
+
+- send a multi-step request and confirm the panel appears
+- verify updates after each `todo_write`
+- refresh the page and confirm the latest plan is restored
+- branch to a different parent message and confirm the plan follows that branch
+
+## Deferred to a Later Chapter
+
+Keep these for a later "full planning" follow-up:
+
+- richer status machine
+- status transition guards
+- stable sorting rules
+- progress summaries
+- multiple simultaneous active items
+- editable user-side task board
+- background execution and scheduling
+
+## Recommendation
+
+Implement `ch12` as the first visible-planning chapter, then treat a later chapter as the advanced version instead of creating a literal `ch03-2` directory.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,7 +10,9 @@ import {
   type ConversationVO,
 } from './api'
 
-const USE_ASSISTANT_UI = true
+// ch12 needs a simple chapter-oriented layout with a dedicated plan panel.
+// Keep the legacy flow active until planning state is wired into assistant-ui.
+const USE_ASSISTANT_UI = false
 
 export default function App() {
   return USE_ASSISTANT_UI ? <AssistantUIApp /> : <LegacyApp />

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -39,16 +39,29 @@ export interface ChatMessageVO {
   model: string
   created_at: number
   rounds?: RoundMessageVO[]
+  plan_state?: PlanningState
+}
+
+export interface PlanItem {
+  content: string
+  status: 'pending' | 'in_progress' | 'completed'
+}
+
+export interface PlanningState {
+  items: PlanItem[]
+  revision: number
+  last_updated_loop: number
 }
 
 export interface SSEMessageVO {
   message_id: string
-  event: 'error' | 'reasoning' | 'content' | 'tool_call' | 'tool_result'
+  event: 'error' | 'reasoning' | 'content' | 'tool_call' | 'tool_result' | 'todo_snapshot'
   content?: string
   reasoning_content?: string
   tool_call?: string
   tool_arguments?: string
   tool_result?: string
+  plan_state?: PlanningState
 }
 
 interface StreamThreadRunArgs {

--- a/frontend/src/components/ChatPanel.tsx
+++ b/frontend/src/components/ChatPanel.tsx
@@ -6,9 +6,11 @@ import {
   streamMessage,
   type ChatMessageVO,
   type ConversationVO,
+  type PlanningState,
   type SSEMessageVO,
 } from '../api'
 import MessageBubble, { ReasoningBlock } from './MessageBubble'
+import TodoPanel from './TodoPanel'
 
 interface StreamingTurn {
   query: string
@@ -25,6 +27,7 @@ interface Props {
 
 export default function ChatPanel({ conversationId, onConversationCreated }: Props) {
   const [history, setHistory] = useState<ChatMessageVO[]>([])
+  const [planState, setPlanState] = useState<PlanningState | null>(null)
   const [streaming, setStreaming] = useState<StreamingTurn | null>(null)
   const [input, setInput] = useState('')
   const [loading, setLoading] = useState(false)
@@ -40,10 +43,12 @@ export default function ChatPanel({ conversationId, onConversationCreated }: Pro
     convIdRef.current = conversationId
     lastMessageIdRef.current = undefined
     setHistory([])
+    setPlanState(null)
     if (!conversationId) return
     listMessages(conversationId)
       .then((msgs) => {
         setHistory(msgs)
+        setPlanState(findLatestPlanState(msgs))
         if (msgs.length > 0) lastMessageIdRef.current = msgs[msgs.length - 1].message_id
       })
       .catch(console.error)
@@ -88,6 +93,9 @@ export default function ChatPanel({ conversationId, onConversationCreated }: Pro
           reasoningCache.current.set(e.message_id, prev + e.reasoning_content)
         }
       }
+      if (e.event === 'todo_snapshot' && e.plan_state) {
+        setPlanState(e.plan_state)
+      }
       setStreaming((prev) => {
         if (!prev) return prev
         const next = { ...prev }
@@ -106,7 +114,10 @@ export default function ChatPanel({ conversationId, onConversationCreated }: Pro
     }, async () => {
       // SSE stream closed — fetch history exactly once
       const msgs = await listMessages(pollConvId).catch(() => null)
-      if (msgs) setHistory(msgs)
+      if (msgs) {
+        setHistory(msgs)
+        setPlanState(findLatestPlanState(msgs))
+      }
       setStreaming(null)
       setLoading(false)
     }, parentMessageId)
@@ -123,90 +134,105 @@ export default function ChatPanel({ conversationId, onConversationCreated }: Pro
     <div style={{
       height: '100%',
       display: 'flex',
-      flexDirection: 'column',
       background: 'var(--bg)',
     }}>
-      {/* Messages */}
-      <div style={{ flex: 1, overflowY: 'auto', padding: '24px 0' }}>
-        <div style={{ padding: '0 24px' }}>
-          {history.length === 0 && !streaming && (
-            <div style={{
-              textAlign: 'center',
-              color: 'var(--text-muted)',
-              marginTop: 80,
-              fontSize: 14,
-            }}>
-              Start a conversation…
-            </div>
-          )}
-          {history.map((msg) => (
-            <MessageBubble
-              key={msg.message_id}
-              msg={msg}
-              reasoning={reasoningCache.current.get(msg.message_id)}
+      <div style={{
+        flex: 1,
+        display: 'flex',
+        flexDirection: 'column',
+      }}>
+        {/* Messages */}
+        <div style={{ flex: 1, overflowY: 'auto', padding: '24px 0' }}>
+          <div style={{ padding: '0 24px' }}>
+            {history.length === 0 && !streaming && (
+              <div style={{
+                textAlign: 'center',
+                color: 'var(--text-muted)',
+                marginTop: 80,
+                fontSize: 14,
+              }}>
+                Start a conversation…
+              </div>
+            )}
+            {history.map((msg) => (
+              <MessageBubble
+                key={msg.message_id}
+                msg={msg}
+                reasoning={reasoningCache.current.get(msg.message_id)}
+              />
+            ))}
+            {streaming && <StreamingBubble turn={streaming} />}
+            <div ref={bottomRef} />
+          </div>
+        </div>
+
+        {/* Input */}
+        <div style={{
+          borderTop: '1px solid var(--border)',
+          padding: '12px 16px',
+          background: 'var(--sidebar-bg)',
+        }}>
+          <div style={{
+            margin: '0 auto',
+            display: 'flex',
+            gap: 8,
+            alignItems: 'flex-end',
+          }}>
+            <textarea
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              onKeyDown={handleKey}
+              placeholder="Send a message… (Enter to send, Shift+Enter for newline)"
+              rows={1}
+              disabled={loading}
+              style={{
+                flex: 1,
+                resize: 'none',
+                background: 'var(--panel-bg)',
+                border: '1px solid var(--border)',
+                borderRadius: 10,
+                padding: '10px 14px',
+                color: 'var(--text)',
+                fontSize: 14,
+                outline: 'none',
+                lineHeight: 1.5,
+                fontFamily: 'inherit',
+                maxHeight: 160,
+                overflowY: 'auto',
+              }}
             />
-          ))}
-          {streaming && <StreamingBubble turn={streaming} />}
-          <div ref={bottomRef} />
+            <button
+              onClick={send}
+              disabled={loading || !input.trim()}
+              style={{
+                background: loading || !input.trim() ? 'var(--border)' : 'var(--accent)',
+                border: 'none',
+                borderRadius: 10,
+                padding: '10px 14px',
+                cursor: loading || !input.trim() ? 'not-allowed' : 'pointer',
+                color: '#fff',
+                display: 'flex',
+                alignItems: 'center',
+                transition: 'background 0.15s',
+              }}
+            >
+              <Send size={16} />
+            </button>
+          </div>
         </div>
       </div>
 
-      {/* Input */}
-      <div style={{
-        borderTop: '1px solid var(--border)',
-        padding: '12px 16px',
-        background: 'var(--sidebar-bg)',
-      }}>
-        <div style={{
-          margin: '0 auto',
-          display: 'flex',
-          gap: 8,
-          alignItems: 'flex-end',
-        }}>
-          <textarea
-            value={input}
-            onChange={(e) => setInput(e.target.value)}
-            onKeyDown={handleKey}
-            placeholder="Send a message… (Enter to send, Shift+Enter for newline)"
-            rows={1}
-            disabled={loading}
-            style={{
-              flex: 1,
-              resize: 'none',
-              background: 'var(--panel-bg)',
-              border: '1px solid var(--border)',
-              borderRadius: 10,
-              padding: '10px 14px',
-              color: 'var(--text)',
-              fontSize: 14,
-              outline: 'none',
-              lineHeight: 1.5,
-              fontFamily: 'inherit',
-              maxHeight: 160,
-              overflowY: 'auto',
-            }}
-          />
-          <button
-            onClick={send}
-            disabled={loading || !input.trim()}
-            style={{
-              background: loading || !input.trim() ? 'var(--border)' : 'var(--accent)',
-              border: 'none',
-              borderRadius: 10,
-              padding: '10px 14px',
-              cursor: loading || !input.trim() ? 'not-allowed' : 'pointer',
-              color: '#fff',
-              display: 'flex',
-              alignItems: 'center',
-              transition: 'background 0.15s',
-            }}
-          >
-            <Send size={16} />
-          </button>
-        </div>
-      </div>
+      <TodoPanel planState={planState} />
     </div>
   )
+}
+
+function findLatestPlanState(messages: ChatMessageVO[]): PlanningState | null {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const state = messages[index]?.plan_state
+    if (state) return state
+  }
+  return null
 }
 
 function StreamingBubble({ turn }: { turn: StreamingTurn }) {

--- a/frontend/src/components/TodoPanel.tsx
+++ b/frontend/src/components/TodoPanel.tsx
@@ -1,0 +1,103 @@
+import type { PlanningState } from '../api'
+
+interface Props {
+  planState: PlanningState | null
+}
+
+const STATUS_LABEL: Record<'pending' | 'in_progress' | 'completed', string> = {
+  pending: 'Pending',
+  in_progress: 'In Progress',
+  completed: 'Completed',
+}
+
+export default function TodoPanel({ planState }: Props) {
+  return (
+    <aside style={{
+      width: 320,
+      borderLeft: '1px solid var(--border)',
+      background: 'var(--sidebar-bg)',
+      padding: '20px 16px',
+      overflowY: 'auto',
+      flexShrink: 0,
+    }}>
+      <div style={{ marginBottom: 16 }}>
+        <div style={{ fontSize: 15, fontWeight: 600, color: 'var(--text)', marginBottom: 4 }}>
+          Current Plan
+        </div>
+        <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>
+          The agent updates this list with `todo_write`.
+        </div>
+      </div>
+
+      {!planState || planState.items.length === 0 ? (
+        <div style={{
+          border: '1px dashed var(--border)',
+          borderRadius: 12,
+          padding: '14px 12px',
+          fontSize: 13,
+          lineHeight: 1.6,
+          color: 'var(--text-muted)',
+          background: 'var(--panel-bg)',
+        }}>
+          No active todo list yet. Once the task becomes multi-step, the agent can publish a plan here.
+        </div>
+      ) : (
+        <>
+          <div style={{ display: 'grid', gap: 10 }}>
+            {planState.items.map((item, index) => {
+              const active = item.status === 'in_progress'
+              const done = item.status === 'completed'
+              return (
+                <div
+                  key={`${planState.revision}-${index}-${item.content}`}
+                  style={{
+                    border: `1px solid ${active ? 'rgba(124,58,237,0.45)' : 'var(--border)'}`,
+                    background: active ? 'rgba(124,58,237,0.12)' : 'var(--panel-bg)',
+                    borderRadius: 12,
+                    padding: '12px 12px 10px',
+                  }}
+                >
+                  <div style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    gap: 8,
+                    marginBottom: 8,
+                  }}>
+                    <span style={{
+                      fontSize: 11,
+                      letterSpacing: '0.04em',
+                      textTransform: 'uppercase',
+                      color: active ? 'var(--accent-light)' : done ? '#86efac' : 'var(--text-muted)',
+                    }}>
+                      {STATUS_LABEL[item.status]}
+                    </span>
+                    <span style={{ fontSize: 11, color: 'var(--text-muted)' }}>
+                      {index + 1}
+                    </span>
+                  </div>
+                  <div style={{
+                    fontSize: 13,
+                    lineHeight: 1.6,
+                    color: done ? 'var(--text-muted)' : 'var(--text)',
+                    textDecoration: done ? 'line-through' : 'none',
+                  }}>
+                    {item.content}
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+
+          <div style={{
+            marginTop: 14,
+            fontSize: 11,
+            color: 'var(--text-muted)',
+          }}>
+            Revision {planState.revision} · Updated in loop {planState.last_updated_loop}
+          </div>
+        </>
+      )}
+    </aside>
+  )
+}

--- a/frontend/src/components/assistant-ui/model-adapter.ts
+++ b/frontend/src/components/assistant-ui/model-adapter.ts
@@ -164,6 +164,8 @@ function applySSEEvent(state: RunState, event: SSEMessageVO): ChatModelRunResult
       break
     case 'error':
       throw new Error(event.content || 'The backend returned an error event while streaming the assistant response')
+    case 'todo_snapshot':
+      return null
     default: {
       const exhaustiveCheck: never = event.event
       throw new Error(`Unsupported SSE event: ${exhaustiveCheck}`)

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -7,8 +7,8 @@
   --border: #2a2d3a;
   --text: #c9d1d9;
   --text-muted: #6e7681;
-  --accent: #7c3aed;
-  --accent-light: #a78bfa;
+  --accent: #0f766e;
+  --accent-light: #2dd4bf;
   --user-bubble: #1e2a3a;
   --assistant-bubble: #1a1d27;
   --tool-bg: #0d1117;


### PR DESCRIPTION
## Summary
- add a new `ch12` web chapter for explicit planning with `todo_write` and nag reminders
- persist plan snapshots on chat messages and stream `todo_snapshot` updates to the frontend
- add a right-side todo panel in the legacy web chat flow and document the new chapter

## Verification
- `go test -v ./ch12/...`
- `pnpm --dir frontend build`

## Notes
- `go test -v ./...` still fails on the pre-existing root file `test_skills.go` because it references missing `shared.SetWorkspaceDir`