### PR TITLE
fix(ch06): TUI 记忆更新未完成显示

### DIFF
--- a/ch06/tui/tui.go
+++ b/ch06/tui/tui.go
@@ -135,7 +135,6 @@ func (m *TuiViewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleStreamMsg(msg)
 	case streamClosedMsg:
 		if m.active != nil {
-			m.active.events = nil
 			m.active.streamClosed = true
 			if m.active.doneReceived {
 				return m.finalizeActiveStream()
@@ -296,11 +295,14 @@ func (m *TuiViewModel) resetOutputSection() {
 }
 
 func (m *TuiViewModel) handleStreamMsg(msg streamMsg) (tea.Model, tea.Cmd) {
-	if m.active == nil || m.active.events == nil {
+	if m.active == nil {
 		return m, nil
 	}
 	m.handleStreamEvent(msg.event)
 	m.refreshLogsViewportContent()
+	if m.active.streamClosed {
+		return m, nil
+	}
 	return m, waitStreamEvent(m.active.events)
 }
 
@@ -385,11 +387,28 @@ func (m *TuiViewModel) stopActiveStream() {
 	m.active = nil
 }
 
+func (m *TuiViewModel) finalizePendingStates() {
+	if m.active == nil {
+		return
+	}
+	success := m.active.doneErr == nil
+	if m.active.policyBody >= 0 && m.active.policyBody < len(m.logs) {
+		m.logs[m.active.policyBody].UpdatePolicyCompleted(success)
+		m.active.policyBody = -1
+	}
+	if m.active.memoryBody >= 0 && m.active.memoryBody < len(m.logs) {
+		m.logs[m.active.memoryBody].UpdateMemoryCompleted(success)
+		m.active.memoryBody = -1
+	}
+}
+
 func (m *TuiViewModel) finalizeActiveStream() (tea.Model, tea.Cmd) {
 	if m.active == nil {
 		m.state = stateIdle
 		return m, nil
 	}
+
+	m.finalizePendingStates()
 
 	err := m.active.doneErr
 	if m.state == stateAborting {


### PR DESCRIPTION
## Summary
- 修复 ch06 TUI 流式结束时，记忆更新/策略状态可能一直显示「运行中」的问题
- 根因是 `streamClosedMsg` 过早将 `events` 置空，队列中未处理的完成事件被丢弃
- 改为用 `streamClosed` 标记 channel 关闭，并在 `finalizeActiveStream` 中兜底补全未完成状态
