### PR TITLE
fix: 关闭各章节流式请求的 stream 以释放 HTTP 连接

### DIFF
--- a/ch01/sdk.go
+++ b/ch01/sdk.go
@@ -46,6 +46,7 @@ func StreamingRequestSDK(ctx context.Context, modelConf shared.ModelConfig, quer
 	}
 
 	stream := client.Chat.Completions.NewStreaming(ctx, req)
+	defer stream.Close()
 
 	for stream.Next() {
 		chunk := stream.Current()
@@ -57,6 +58,5 @@ func StreamingRequestSDK(ctx context.Context, modelConf shared.ModelConfig, quer
 
 	if stream.Err() != nil {
 		log.Fatalf("stream error: %v", stream.Err())
-		return
 	}
 }

--- a/ch03/agent.go
+++ b/ch03/agent.go
@@ -99,6 +99,9 @@ func (a *Agent) RunStreaming(ctx context.Context, query string, viewCh chan Mess
 				}
 			}
 		}
+		// 显式关闭流以释放底层 HTTP 连接。不能用 defer：stream 在 agent 主循环里每轮重建，
+		// defer 会等到函数返回才关闭，反而累积泄漏。Close 不影响后续 stream.Err() 读取。
+		stream.Close()
 		if err := stream.Err(); err != nil {
 			viewCh <- MessageVO{
 				Type:    MessageTypeError,

--- a/ch04/agent.go
+++ b/ch04/agent.go
@@ -123,6 +123,9 @@ func (a *Agent) RunStreaming(ctx context.Context, query string, viewCh chan Mess
 				}
 			}
 		}
+		// 显式关闭流以释放底层 HTTP 连接。不能用 defer：stream 在 agent 主循环里每轮重建，
+		// defer 会等到函数返回才关闭，反而累积泄漏。Close 不影响后续 stream.Err() 读取。
+		stream.Close()
 		if err := stream.Err(); err != nil {
 			viewCh <- MessageVO{
 				Type:    MessageTypeError,

--- a/ch05/agent.go
+++ b/ch05/agent.go
@@ -138,6 +138,9 @@ func (a *Agent) RunStreaming(ctx context.Context, query string, viewCh chan Mess
 				}
 			}
 		}
+		// 显式关闭流以释放底层 HTTP 连接。不能用 defer：stream 在 agent 主循环里每轮重建，
+		// defer 会等到函数返回才关闭，反而累积泄漏。Close 不影响后续 stream.Err() 读取。
+		stream.Close()
 		if err := stream.Err(); err != nil {
 			viewCh <- MessageVO{
 				Type:    MessageTypeError,

--- a/ch06/agent.go
+++ b/ch06/agent.go
@@ -148,6 +148,9 @@ func (a *Agent) RunStreaming(ctx context.Context, query string, viewCh chan Mess
 				}
 			}
 		}
+		// 显式关闭流以释放底层 HTTP 连接。不能用 defer：stream 在 agent 主循环里每轮重建，
+		// defer 会等到函数返回才关闭，反而累积泄漏。Close 不影响后续 stream.Err() 读取。
+		stream.Close()
 		if err := stream.Err(); err != nil {
 			viewCh <- MessageVO{
 				Type:    MessageTypeError,

--- a/ch08/agent.go
+++ b/ch08/agent.go
@@ -152,6 +152,9 @@ func (a *Agent) RunStreaming(ctx context.Context, query string, viewCh chan Mess
 				}
 			}
 		}
+		// 显式关闭流以释放底层 HTTP 连接。不能用 defer：stream 在 agent 主循环里每轮重建，
+		// defer 会等到函数返回才关闭，反而累积泄漏。Close 不影响后续 stream.Err() 读取。
+		stream.Close()
 		if err := stream.Err(); err != nil {
 			viewCh <- MessageVO{
 				Type:    MessageTypeError,

--- a/ch09/agent.go
+++ b/ch09/agent.go
@@ -152,6 +152,9 @@ func (a *Agent) RunStreaming(ctx context.Context, query string, viewCh chan Mess
 				}
 			}
 		}
+		// 显式关闭流以释放底层 HTTP 连接。不能用 defer：stream 在 agent 主循环里每轮重建，
+		// defer 会等到函数返回才关闭，反而累积泄漏。Close 不影响后续 stream.Err() 读取。
+		stream.Close()
 		if err := stream.Err(); err != nil {
 			viewCh <- MessageVO{
 				Type:    MessageTypeError,

--- a/ch10/agent/agent.go
+++ b/ch10/agent/agent.go
@@ -121,6 +121,9 @@ func (a *Agent) RunStreaming(ctx context.Context, history []openai.ChatCompletio
 				}
 			}
 		}
+		// 显式关闭流以释放底层 HTTP 连接。不能用 defer：stream 在 agent 主循环里每轮重建，
+		// defer 会等到函数返回才关闭，反而累积泄漏。Close 不影响后续 stream.Err() 读取。
+		stream.Close()
 		if err := stream.Err(); err != nil {
 			eventCh <- StreamEvent{Event: EventError, Content: err.Error()}
 			return RunResult{}, err


### PR DESCRIPTION
## Summary

`openai-go` 的 `Stream[T]` 实现了 `io.Closer`，底层是 HTTP response body。之前所有章节的流式请求都没调用 `Close()`，会泄漏连接。

- **ch01**：`stream` 在函数顶层、不在循环里，用 `defer stream.Close()`；顺手删除 `log.Fatalf` 之后的死代码 `return`
- **ch03-ch10**：`stream` 在 agent 主循环 `for {}` 里每轮重建，若用 `defer` 会累积到函数返回才关闭，反而泄漏。改为在内层 `for stream.Next()` 结束后显式调用 `stream.Close()`，并加注释说明为何不用 `defer`（防止以后被误改回 defer）

`Close()` 不会影响后续 `stream.Err()` 读取——前者只关闭 decoder，后者读取的是已经存好的 `s.err` 字段（见 [ssestream.go](https://github.com/openai/openai-go/blob/main/packages/ssestream/ssestream.go)）。

## 受影响章节/包

- ch01/sdk.go
- ch03/agent.go
- ch04/agent.go
- ch05/agent.go
- ch06/agent.go
- ch08/agent.go
- ch09/agent.go
- ch10/agent/agent.go

## Test plan

- [x] `gofmt -l .` 无输出（格式干净）
- [x] `go build ./...` 通过
- [x] `go test ./...` 全部通过（ch05/ch08/ch09 context 包 + ch10 server 包测试 ok）